### PR TITLE
Add white background to controls 

### DIFF
--- a/src/components/PrimaryMap.css
+++ b/src/components/PrimaryMap.css
@@ -159,17 +159,20 @@
   left: initial;
   top: 120px;
   right: 10px;
-  width: 20px;
+  width: 18px;
   box-shadow: none;
-  opacity: .5;
+  opacity: .6;
   color: var(--COLOR_TEXT);
   overflow: visible;
   height: 100px;
+  background-color: white;
+  border-radius: 2px;
+  border: 1px solid #555;
 }
 
 :global(.ol-zoomslider):hover {
-  background-color: transparent;
-  opacity: 1;
+  background-color: white;
+  opacity: .9;
   color: var(--COLOR_BRAND_DARK);
 }
 
@@ -192,7 +195,6 @@
   border-radius: 50%;
   color: inherit;
   background-color: currentColor;
-  box-shadow: 0 0 0 1px rgba(0,0,0,.1), 0 0 0 3px rgba(255,255,255,.4);
 }
 
 /* OpenLayers Controls: Rotation Reset
@@ -221,8 +223,12 @@
   border: none;
   font-family: Inconsolata, monospace;
   font-size: 9px;
-  opacity: .4;
+  font-weight: bold;
+  opacity: .6;
   color: black;
+  background-color: white;
+  padding: 2px;
+  border-radius: 5px;
 }
 
 :global(.ol-scale-line-inner):before {
@@ -246,10 +252,13 @@
   left: 10px;
   line-height: 11px;
   color: black;
-  opacity: .4;
+  opacity: .6;
   font-family: inherit;
   font-size: 11px;
   font-weight: bold;
+  background-color: white;
+  padding: 1px;
+  border-radius: 3px;
 }
 
 /* OpenLayers Controls: Attributions


### PR DESCRIPTION
Add white background to controls that tend to disappear based on the base layer.  A dark base layer would cause the mouse position, scale and zoom slider to blend in to the background.