### PR TITLE
Faster compilation using ATL in Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node": "^5.7.0"
   },
   "devDependencies": {
+    "awesome-typescript-loader": "3.1.2",
     "chai": "3.5.0",
     "copy-webpack-plugin": "4.0.1",
     "css-loader": "0.26.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,9 @@
     "./typings/index.d.ts",
     "./beachfront.d.ts",
     "./src/**/*"
-  ]
+  ],
+  "awesomeTypescriptLoaderOptions": {
+    "useTranspileModule": true,
+    "useCache": true
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const cssnext = require('postcss-cssnext')
 const cssimport = require('postcss-import')
 const pkg = require('./package')
+const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin
 
 const __environment__ = process.env.NODE_ENV || 'development'
 
@@ -64,7 +65,7 @@ module.exports = {
     loaders: [
       {
         test: /\.tsx?$/,
-        loader: 'ts',
+        loader: 'awesome-typescript-loader',
         exclude: /node_modules/
       },
       {
@@ -104,6 +105,7 @@ module.exports = {
   },
 
   plugins: [
+    new CheckerPlugin(),
     new CopyWebpackPlugin([{
       from: require.resolve('openlayers/dist/ol-debug.js'),
       to: 'ol.js',


### PR DESCRIPTION
Drop in replacement for `ts-loader` using `awesome-typescript-loader`. Also, introduce its `CheckerPlugin`, which forks type checking into a separate process, allowing the recompilation of the package (via webpack-dev-server) to happen far faster.