### PR TITLE
21414 inactivity

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ const time = {millisecond: 1, second: 1000, minute: 60000}
 export const RECORD_POLLING_INTERVAL = 30 * time.second
 export const UPDATE_WORKER_INTERVAL = 15 * time.minute
 
-export const SESSION_IDLE_TIMEOUT = 2
+export const SESSION_IDLE_TIMEOUT = 15
 export const SESSION_IDLE_UNITS = 'minutes'
 export const SESSION_IDLE_INTERVAL = time.minute
 export const SESSION_IDLE_STORE = 'lastActivity'

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,8 +26,10 @@ const time = {millisecond: 1, second: 1000, minute: 60000}
 export const RECORD_POLLING_INTERVAL = 30 * time.second
 export const UPDATE_WORKER_INTERVAL = 15 * time.minute
 
-export const SESSION_IDLE_TIMEOUT = 15
+export const SESSION_IDLE_TIMEOUT = 2
+export const SESSION_IDLE_UNITS = 'minutes'
 export const SESSION_IDLE_INTERVAL = time.minute
+export const SESSION_IDLE_STORE = 'lastActivity'
 
 export const BASEMAP_TILE_PROVIDERS = [
   {


### PR DESCRIPTION
Fix multiple tab issue by keeping track of the idle time in local storage.  We could no longer just keep a minute counter (because multiple tabs would each increment the counter) so it had to change to a last active timestamp.  Then we just check if the different between then and now has been longer than 15 minutes