### PR TITLE
Download button changes to support more than 2 download formats.

### DIFF
--- a/src/components/JobDownload.css
+++ b/src/components/JobDownload.css
@@ -17,19 +17,21 @@
 @import '../styles/constants.css';
 
 :root {
-  --border-radius: 8px;
+  --border-radius: 6px;
 }
 
 .root,
 .root > a,
 .root > a:before,
-.root > ul,
-.root > ul > li {
+ul.list,
+ul.list > li {
   transition: background-color 150ms ease-in-out;
 }
 
-.root > ul {
+ul.list {
   background-color: var(--COLOR_CONTROL);
+  border-radius: var(--border-radius);
+  border-bottom-right-radius: 0;
   bottom: 0;
   display: flex;
   font-size: 13px;
@@ -43,12 +45,11 @@
   z-index: 9;
 }
 
-.root:hover > ul {
+.root:hover > ul.list {
   background-color: var(--COLOR_BRAND_DARK);
-  border-radius: 4px;
 }
 
-.root > ul > li {
+ul.list > li {
   align-items: center;
   box-shadow: inset -1px 0 rgba(255, 255, 255, 0.2), inset 0 1px rgba(255, 255, 255, 0.2);
   display: flex;
@@ -56,53 +57,54 @@
   min-height: 28px;
 }
 
-.root > ul > li:first-child {
+ul.list > li:first-child {
   border-top-left-radius: var(--border-radius);
   border-top-right-radius: var(--border-radius);
 }
 
-.root > ul > li:last-child {
+ul.list > li:last-child {
   border-bottom-left-radius: var(--border-radius);
   border-bottom-right-radius: var(--border-radius);
 }
 
-.root > ul > li:hover {
+ul.list > li:hover {
   background-color: hsl(202, 80%, 20%);
 }
 
-.root > ul > li > a {
+ul.list > li > a {
   flex: 1 0 auto;
   padding: 0.25em 0.75em;
   white-space: nowrap;
 }
 
-.root > ul > li > a > i:global(.fa) {
-  padding-right: 0.25em;
+ul.list > li > a > i:global(.fa) {
+  padding-right: 0.5em;
+  text-align: center;
   width: 17px;
 }
 
 .root.errors,
-.root.errors > ul > li.error,
-:global(.JobStatus-controls):hover .root.errors > ul > li.error,
+.root.errors > ul.list > li.error,
+:global(.JobStatus-controls):hover .root.errors > ul.list > li.error,
 :global(.JobStatus-controls):hover .root.errors > a:before {
   background-color: indianred;
 }
 
-.root.errors > ul > li.error:hover,
+.root.errors > ul.list > li.error:hover,
 .root.errors:hover,
 :global(.JobStatus-controls):hover .root.errors:hover > a:before,
-:global(.JobStatus-controls):hover .root.errors:hover > ul > li.error {
+:global(.JobStatus-controls):hover .root.errors:hover > ul.list > li.error {
   background-color: hsl(0, 53%, 48%);
 }
 
-:global(.JobStatus-controls):hover .root.errors > ul > li.error:hover {
+:global(.JobStatus-controls):hover .root.errors > ul.list > li.error:hover {
   background-color: hsl(0, 53%, 38%);
 }
 
 .root.errors > .error {
   background-color: indianred;
   border: solid 3px whitesmoke;
-  border-radius: 8px;
+  border-radius: var(--border-radius);
   box-shadow:
     0 24px 38px 3px rgba(0, 0, 0, 0.14),
     0 9px 46px 8px rgba(0, 0, 0, 0.12),

--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -17,6 +17,7 @@
 @import '../styles/constants.css';
 
 :root {
+  --border-radius: 6px;
   --padding-size: 15px;
   --bgcolor-active: #f2faff;
   --bgcolor-failed: var(--COLOR_RED);
@@ -39,11 +40,12 @@
    ========================================================================= */
 
 .root {
+  box-shadow: inset 0 1px hsl(202, 30%, 90%);
   display: flex;
   flex-direction: column;
   background-color: #fff;
-  margin-bottom: 1px;
   font-size: 14px;
+  overflow: visible;
   position: relative;
 }
 
@@ -310,27 +312,30 @@
 .controls > .download,
 .controls > .download > a,
 .controls > .download > a:before {
-  transition: background-color 150ms ease-in-out;
+  transition: 150ms ease-in-out;
 }
 
-.controls > * + * {
-  box-shadow: inset 0 1px rgba(255, 255, 255, 0.2);
+.controls > a,
+.controls > a:before,
+.controls > .download > a,
+.controls > .download > a:before {
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .controls > .download:first-child > a:before,
 .controls > a:first-child:before {
-  border-top-left-radius: 4px;
+  border-top-left-radius: var(--border-radius);
 }
 
 .controls > .download:last-child > a:before,
 .controls > a:last-child:before {
-  border-bottom-left-radius: 4px;
+  border-bottom-left-radius: var(--border-radius);
 }
 
-.controls > .download:hover,
-.controls > .download:hover > a:before,
 .controls > a:hover,
-.controls > a:hover:before {
+.controls > a:hover:before,
+.controls > .download:hover,
+.controls > .download:hover > a:before {
   background-color: var(--control-bgcolor-hover);
 }
 
@@ -355,7 +360,6 @@
   bottom: 0;
   width: 0;
   overflow: hidden;
-  transition: background-color 150ms ease-in-out, width 150ms ease-in-out;
   white-space: nowrap;
   background-color: var(--control-bgcolor);
 }

--- a/src/components/JobStatusList.css
+++ b/src/components/JobStatusList.css
@@ -20,6 +20,10 @@
   composes: submenu from '../styles/menus.css';
 }
 
+.root header {
+  z-index: 1;
+}
+
 .communicationError {
   padding: 15px;
   background-color: var(--COLOR_RED);
@@ -35,11 +39,11 @@
   font-size: 1.3em;
 }
 
-.root ul {
+.root > ul {
   background-color: hsl(202, 30%, 90%);
 }
 
-.isEmpty ul {
+.isEmpty > ul {
   background-color: white;
 }
 

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -48,9 +48,9 @@ export class Timestamp extends React.Component<Props, State> {
   }
 
   render() {
-    const t = moment(this.props.timestamp)
+    const t = moment.utc(this.props.timestamp)
     const relativeTimestamp = t.fromNow()
-    const staticTimestamp   = t.format('llll')
+    const staticTimestamp   = t.local().format('llll')
     return (
       <span className={`${styles.root} ${this.props.className}`}
             title={this.state.relative ? staticTimestamp : relativeTimestamp}


### PR DESCRIPTION
This will work perfectly fine with only 2 download types, as we have now, but it will also support _n_ types for the future.

There is a section that is currently commented out in `src/components/JobDownload.tsx` to support the Shapefile download.  Just uncomment and maybe tweak when that is supported by bf-api.