### PR TITLE
Temporarily disable geoserver proxy

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -1241,7 +1241,8 @@ function detectionTileLoadFunction(imageTile, src) {
     delete imageTile.loadingError
     imageTile.getImage().src = tileErrorPlaceholder
   } else {
-    const client = new XMLHttpRequest()
+    imageTile.getImage().src = src
+    /*const client = new XMLHttpRequest()
     client.open('GET', src)
     client.withCredentials = true
     client.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
@@ -1256,14 +1257,14 @@ function detectionTileLoadFunction(imageTile, src) {
       const imageUrl = urlCreator.createObjectURL(blob)
       imageTile.getImage().src = imageUrl
     }
-    client.send()
+    client.send()*/
   }
 }
 
-function getCookie(name) {
+/*function getCookie(name) {
   const match = document.cookie.match(new RegExp(name + '=([^;]+)'))
   if (match) {
     return match[1]
   }
   return null
-}
+}*/


### PR DESCRIPTION
This change goes along with an api change.

This can be reverted once we figure out the geoserver issues.