### PR TITLE
Sort jobs list

### DIFF
--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-
 const styles: any = require('./JobStatusList.css')
 
 import * as React from 'react'
 import {JobStatus} from './JobStatus'
+import * as moment from 'moment'
 
 interface Props {
   activeIds: string[]
@@ -52,7 +52,9 @@ export const JobStatusList = ({
 
       {!jobs.length ? (
         <li className={styles.placeholder}>You haven't started any jobs yet</li>
-      ) : jobs.map(job => (
+      ) : jobs.sort((job1, job2) => {
+        return moment(job1.properties.created_on).isBefore(job2.properties.created_on) ? 1 : -1
+      }).map(job => (
         <JobStatus
           key={job.id}
           isActive={activeIds.includes(job.id)}


### PR DESCRIPTION
This is a quick fix for sorting the jobs list so the newer jobs are always at the top

So the only time this won't bring a job the user just "created" to the top of the list is if it's a redundant job that was created by someone else in the past.