### PR TITLE
BT-292 - Fix fullscreen CSS

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -55,6 +55,31 @@ body {
   bottom: var(--CLASSIFICATION_BANNER_HEIGHT);
 }
 
+.map:-moz-full-screen {
+  height: 100%;
+  top:0;
+  bottom:0;
+  left:0;
+}
+.map:-webkit-full-screen {
+  height: 100%;
+  top:0;
+  bottom:0;
+  left:0;
+}
+.map:-ms-fullscreen {
+  height: 100%;
+  top:0;
+  bottom:0;
+  left:0;
+}
+.map:fullscreen {
+  height: 100%;
+  top:0;
+  bottom:0;
+  left:0;
+}
+
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
   /* IE10+ CSS styles go here */
   .navigation {


### PR DESCRIPTION
So here's a start to how this should work. The problem here is that by default it removes all other divs and we probably want to keep the classification banner at the top and bottom even in fullscreen mode.

Here's an example i'm using to try to get that working:
https://openlayers.org/en/latest/examples/full-screen-source.html

If we're ok with the classification banner disappearing when going to fullscreen mode, then this is good to go now. (this is actually how it worked before and adheres to the acceptance criteria on the ticket)

EDIT: After talking with Wayne the classification banner disappearing is most likely a problem for us, but that was the functionality before this change anyhow.