### PR TITLE
Fix backward sort icons in imagery search list.

### DIFF
--- a/src/components/ImagerySearchList.tsx
+++ b/src/components/ImagerySearchList.tsx
@@ -103,9 +103,9 @@ export class ImagerySearchList extends React.Component<Props, State> {
 
       if (props.name === this.state.sortBy) {
         if (this.state.sortReverse) {
-          icon += '-asc'
-        } else {
           icon += '-desc'
+        } else {
+          icon += '-asc'
         }
       }
 


### PR DESCRIPTION
The sort icons in the **Images Found** columns were facing the wrong way, with the narrow end in the direction that values were _increasing_ rather than decreasing.

### Before
![selection_013](https://user-images.githubusercontent.com/3220897/44059650-f8681af4-9f06-11e8-8022-396c4c737655.png)

### After
![selection_012](https://user-images.githubusercontent.com/3220897/44059661-ff959130-9f06-11e8-9a43-5d0c6b785c69.png)
