### PR TITLE
Fix bug where Images Found items could shift order as the mouse moved.

### DIFF
--- a/src/components/ImagerySearchList.tsx
+++ b/src/components/ImagerySearchList.tsx
@@ -54,20 +54,21 @@ export class ImagerySearchList extends React.Component<Props, State> {
     const compareAcquiredDate = (a, b) => moment.utc(a.properties.acquiredDate).diff(b.properties.acquiredDate)
     const compareBbox = (a, b) => b.bbox[3] - a.bbox[3] || a.bbox[0] - b.bbox[0]
     const compareCloudCover = (a, b) => a.properties.cloudCover - b.properties.cloudCover
-    const compareSensorName = (a, b) => a.properties.sensorName < b.properties.sensorName ? -1 : a.properties.sensorName > b.properties.sensorName ? 1 : 0
+    const compareSensorName = (a, b) => a.properties.sensorName.localeCompare(b.properties.sensorName)
+    const compareId = (a, b) => a.id.localeCompare(b.id)
 
     this.compare = {
       acquiredDate(a, b) {
-        return compareAcquiredDate(a, b) || compareBbox(a, b)
+        return compareAcquiredDate(a, b) || compareBbox(a, b) || compareId(a, b)
       },
       bbox(a, b) {
-        return compareBbox(a, b) || compareAcquiredDate(a, b)
+        return compareBbox(a, b) || compareAcquiredDate(a, b) || compareId(a, b)
       },
       cloudCover(a, b) {
-        return compareCloudCover(a, b) || compareAcquiredDate(a, b)
+        return compareCloudCover(a, b) || compareAcquiredDate(a, b) || compareId(a, b)
       },
       sensorName(a, b) {
-        return compareSensorName(a, b) || compareAcquiredDate(a, b)
+        return compareSensorName(a, b) || compareAcquiredDate(a, b) || compareId(a, b)
       },
     }
 


### PR DESCRIPTION
The order of items in the **Images Found** list was sometimes shifting erratically on hover due to identical values in the sorting column. I used the id of each item in the list as a fallback to ensure that the order always stays consistent.

![peek 2018-08-09 18-10](https://user-images.githubusercontent.com/3220897/44059913-bb95cbac-9f07-11e8-905b-d8d0907554f0.gif)
