### PR TITLE
Bring selected imagery to front. Don't light up polygons on hover.

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -802,6 +802,8 @@ export class PrimaryMap extends React.Component<Props, State> {
           })
         }
 
+        layer.setZIndex(1)
+
         console.log('Created preview layer', layer)
 
         this.subscribeToLoadEvents(layer)
@@ -1157,9 +1159,6 @@ function generateHoverInteraction(...layers) {
     multi: true,
     condition: e => condition.pointerMove(e) && condition.noModifierKeys(e),
     style: new Style({
-      fill: new Fill({
-        color: 'rgba(255, 255, 255, 0.12)',
-      }),
       stroke: new Stroke({
         color: 'hsla(200, 70%, 90%, 0.8)',
         width: 4,


### PR DESCRIPTION
It was possible for preview images with lots of other imagery in the same area to become obscured by the other polygons, making the preview image hard to see. The mouse hover effect would also brighten the polygons, compounding the issue. I brought the selected imagery to the front and removed the brightening effect when hovering over polygons, so that only their borders light up on hover.

### Before
![selection_016](https://user-images.githubusercontent.com/3220897/44060378-5c1321fa-9f09-11e8-98cc-049fe85f4eed.png)
![selection_017](https://user-images.githubusercontent.com/3220897/44060379-5db59c86-9f09-11e8-9196-45abc04bd188.png)

### After
![selection_018](https://user-images.githubusercontent.com/3220897/44060392-6c5d8a6e-9f09-11e8-8dfd-c6c8ba1fce76.png)
![selection_019](https://user-images.githubusercontent.com/3220897/44060398-6e1e5c34-9f09-11e8-835d-758457ddb4c5.png)