### PR TITLE
Don't hide Jobs menu when clicking "View On Map" button.

### DIFF
--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -130,7 +130,7 @@ export class JobStatus extends React.Component<Props, State> {
             onMouseLeave={() => this.setState({ isControlHover: false })}
           >
             <Link
-              pathname="/"
+              pathname="/jobs"
               search={`?jobId=${id}`}
               title="View on Map"
               onClick={this.props.onNavigate}>


### PR DESCRIPTION
The Jobs menu would hide any time you click "View On Map", which created a frustrating workflow if you want to look at several jobs in quick succession. It should stay open now.

![selection_020](https://user-images.githubusercontent.com/3220897/44124147-8a5a3184-9fe0-11e8-8f9d-5224dfd27ae2.png)
