### PR TITLE
Separate pins and frames

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -543,8 +543,8 @@ export class PrimaryMap extends React.Component<Props, State> {
         this.frameLayer,
         this.drawLayer,
         this.imageryLayer,
-        this.highlightLayer,
         this.pinLayer,
+        this.highlightLayer,
       ],
       target: this.refs.container,
       view: new View({
@@ -1075,7 +1075,7 @@ function generateFeatureDetailsOverlay(componentRef) {
 
 function generatePinLayer() {
   return new VectorLayer({
-    zIndex: 3
+    zIndex: 3,
     source: new VectorSource(),
     style(feature: Feature, resolution: number) {
       const isClose = resolution < RESOLUTION_CLOSE

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -1074,8 +1074,7 @@ function generateFeatureDetailsOverlay(componentRef) {
 }
 
 function generatePinLayer() {
-  return new VectorLayer({
-    zIndex: 3,
+  const layer = new VectorLayer({
     source: new VectorSource(),
     style(feature: Feature, resolution: number) {
       const isClose = resolution < RESOLUTION_CLOSE
@@ -1151,6 +1150,10 @@ function generatePinLayer() {
       }
     },
   })
+
+  layer.setZIndex(3)
+
+  return layer
 }
 
 function generateFrameLayer() {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -1161,86 +1161,15 @@ function generateFrameLayer() {
     source: new VectorSource(),
     style(feature: Feature, resolution: number) {
       const isClose = resolution < RESOLUTION_CLOSE
-
-      switch (feature.get(KEY_TYPE)) {
-        case TYPE_DIVOT_INBOARD:
-          return new Style({
-            image: new RegularShape({
-              angle: Math.PI / 4,
-              points: 4,
-              radius: 5,
-              fill: new Fill({
-                color: 'black',
-              }),
-            }),
-          })
-        case TYPE_DIVOT_OUTBOARD:
-          return new Style({
-            image: new RegularShape({
-              angle: Math.PI / 4,
-              points: 4,
-              radius: 10,
-              stroke: new Stroke({
-                color: 'black',
-                width: 1,
-              }),
-              fill: new Fill({
-                color: getColorForStatus(feature.get(KEY_STATUS)),
-              }),
-            }),
-          })
-        case TYPE_STEM:
-          return new Style({
-            stroke: new Stroke({
-              color: 'black',
-              width: 1,
-            }),
-          })
-        case TYPE_LABEL_MAJOR:
-          return new Style({
-            text: new Text({
-              fill: new Fill({
-                color: isClose ? 'black' : 'transparent',
-              }),
-              offsetX: 13,
-              offsetY: 1,
-              font: 'bold 17px Catamaran, Verdana, sans-serif',
-              text: feature.get(KEY_NAME).toUpperCase(),
-              textAlign: 'left',
-              textBaseline: 'middle',
-            }),
-          })
-        case TYPE_LABEL_MINOR:
-          const name = feature.get(KEY_NAME)
-          const sceneId = normalizeSceneId(feature.get(KEY_SCENE_ID))
-
-          return new Style({
-            text: new Text({
-              fill: new Fill({
-                color: isClose ? 'rgba(0,0,0,.6)' : 'transparent',
-              }),
-              offsetX: 13,
-              offsetY: 15,
-              font: '11px Verdana, sans-serif',
-              text: ([
-                feature.get(KEY_STATUS),
-                sceneId !== name ? sceneId : null,
-              ].filter(Boolean)).join(' // ').toUpperCase(),
-              textAlign: 'left',
-              textBaseline: 'middle',
-            }),
-          })
-        default:
-          return new Style({
-            stroke: new Stroke({
-              color: 'rgba(0, 0, 0, .4)',
-              lineDash: [10, 10],
-            }),
-            fill: new Fill({
-              color: isClose ? 'transparent' : 'hsla(202, 100%, 85%, 0.5)',
-            }),
-          })
-      }
+      return new Style({
+        stroke: new Stroke({
+          color: 'rgba(0, 0, 0, .4)',
+          lineDash: [10, 10],
+        }),
+        fill: new Fill({
+          color: isClose ? 'transparent' : 'hsla(202, 100%, 85%, 0.5)',
+        }),
+      })
     },
   })
 }

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -524,7 +524,7 @@ export class PrimaryMap extends React.Component<Props, State> {
 
     this.hoverInteraction = generateHoverInteraction(this.imageryLayer)
 
-    this.selectInteraction = generateSelectInteraction(this.frameLayer, this.imageryLayer)
+    this.selectInteraction = generateSelectInteraction(this.frameLayer, this.imageryLayer, this.pinLayer)
     this.selectInteraction.on('select', this.handleSelect)
 
     this.featureDetailsOverlay = generateFeatureDetailsOverlay(this.refs.featureDetails)


### PR DESCRIPTION
The frames (polygonal outlines/footprints) of a shoreline detection result and the pins (also called divots in the code) need to have different zIndex values. The frames should appear at the bottom of the stack, beneath the imagery and shoreline vector layers, and the pins should appear at the top of the stack - above the imagery/vectors.  Initially the frames and pins were in the same layer, so the zIndex could not be independently set for these two feature sources. This change breaks up the frames layer into two separate layers - one for frames and one for pins. In this way, we can change the zIndex of each independently. 