### PR TITLE
Fit map to job's extents when clicking "View on Map".

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -47,7 +47,7 @@ import * as productLinesService from '../api/productLines'
 import * as sessionService from '../api/session'
 import * as statusService from '../api/status'
 import {createCollection, Collection} from '../utils/collections'
-import {getFeatureCenter} from '../utils/geometries'
+import {featureToExtent, getFeatureCenter} from '../utils/geometries'
 import {
   RECORD_POLLING_INTERVAL,
   SESSION_IDLE_INTERVAL,
@@ -133,6 +133,7 @@ export class Application extends React.Component<Props, State> {
     this.handleSelectFeature = this.handleSelectFeature.bind(this)
     this.navigateTo = this.navigateTo.bind(this)
     this.panTo = this.panTo.bind(this)
+    this.panToExtent = this.panToExtent.bind(this)
     this.logout = this.logout.bind(this)
     this.startIdleTimer = this.startIdleTimer.bind(this)
     this.stopIdleTimer = this.stopIdleTimer.bind(this)
@@ -496,7 +497,8 @@ export class Application extends React.Component<Props, State> {
 
   private handleNavigateToJob(loc) {
     this.navigateTo(loc)
-    this.panTo(getFeatureCenter(this.state.jobs.records.find(j => loc.search.includes(j.id))))
+    const feature = this.state.jobs.records.find(j => loc.search.includes(j.id))
+    this.panToExtent(featureToExtent(feature))
   }
 
   private handlePanToProductLine(productLine) {
@@ -604,7 +606,19 @@ export class Application extends React.Component<Props, State> {
       mapView: Object.assign({}, this.state.mapView, {
         center: point,
         zoom,
+        extent: null,
       }),
+    })
+  }
+
+  private panToExtent(extent: ol.Extent) {
+    this.setState({
+      mapView: {
+        ...this.state.mapView,
+        center: null,
+        zoom: null,
+        extent,
+      },
     })
   }
 

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -144,8 +144,9 @@ interface State {
 
 export interface MapView {
   basemapIndex: number
-  center: [number, number]
-  zoom: number
+  center?: [number, number]
+  zoom?: number
+  extent?: ol.Extent
 }
 
 export class PrimaryMap extends React.Component<Props, State> {
@@ -193,7 +194,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.renderFrames()
     this.renderImagery()
     this.renderImagerySearchResultsOverlay()
-    this.updateView()
+    this.updateView(2000)
 
     if (this.props.bbox) {
       this.renderImagerySearchBbox()
@@ -566,7 +567,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.map.on('measure:end', this.handleMeasureEnd)
   }
 
-  private updateView() {
+  private updateView(duration?: number) {
     if (this.skipNextViewUpdate) {
       this.skipNextViewUpdate = false
       return
@@ -576,15 +577,23 @@ export class PrimaryMap extends React.Component<Props, State> {
       return
     }
 
-    const {basemapIndex, zoom, center} = this.props.view
+    const {basemapIndex, zoom, center, extent} = this.props.view
     this.setState({ basemapIndex })
     const view = this.map.getView()
 
-    view.animate({
-      center: view.constrainCenter(proj.transform(center, WGS84, WEB_MERCATOR)),
-      duration: 2000,
-      zoom: zoom,
-    })
+    if (extent) {
+      view.fit(extent, {
+        padding: [100, 100, 100, 100],
+        constrainResolution: false,
+        duration,
+      })
+    } else {
+      view.animate({
+        center: view.constrainCenter(proj.transform(center, WGS84, WEB_MERCATOR)),
+        zoom,
+        duration,
+      })
+    }
   }
 
   private renderDetections() {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -407,15 +407,16 @@ export class PrimaryMap extends React.Component<Props, State> {
     const zoom = view.getZoom() || MIN_ZOOM  // HACK -- sometimes getZoom returns undefined...
 
     // Don't emit false positives
-    if (!this.props.view
-      || this.props.view.center[0] !== center[0]
-      || this.props.view.center[1] !== center[1]
-      || this.props.view.zoom !== zoom
-      || this.props.view.basemapIndex !== basemapIndex
-    ) {
-      this.skipNextViewUpdate = true
-      this.props.onViewChange({ basemapIndex, center, zoom })
+    if (this.props.view
+      && this.props.view.center
+      && this.props.view.center[0] === center[0]
+      && this.props.view.zoom === zoom
+      && this.props.view.basemapIndex === basemapIndex) {
+      return
     }
+
+    this.skipNextViewUpdate = true
+    this.props.onViewChange({ basemapIndex, center, zoom })
   }
 
   private emitDeselectAll() {


### PR DESCRIPTION
This was using a hardcoded zoom level before, so that when you clicked "View on Map" sometimes you would end up viewing the job way too close on the map, and other times way too far. It should now fit the job within the map consistently.

I also removed the animation duration for "View on Map", since it looked very awkward when the map was already zoomed it, just panning super quickly across the map.

### Before
![screen shot 2018-08-15 at 8 02 48 pm](https://user-images.githubusercontent.com/3220897/44185205-c80c8580-a0c7-11e8-974e-1da6b3e20032.jpg)

### After
![screen shot 2018-08-15 at 8 03 12 pm](https://user-images.githubusercontent.com/3220897/44185208-cc38a300-a0c7-11e8-9c56-2fa0fe227972.jpg)