### PR TITLE
Consistent Section Header Size

### DIFF
--- a/src/components/ImagerySearchList.css
+++ b/src/components/ImagerySearchList.css
@@ -18,7 +18,6 @@
 
 .results > h2 {
   cursor: pointer;
-  font-size: 1em;
 }
 
 .results table {


### PR DESCRIPTION
The Imagery Search section header was specified as a different size than the rest of the headers. I removed that custom style to make it inherit the styling for the other headers, so they can be consistent. 