### PR TITLE
Increase Scale Bar Font Size

### DIFF
--- a/src/components/PrimaryMap.css
+++ b/src/components/PrimaryMap.css
@@ -292,7 +292,7 @@
   margin: 0 auto;
   border: none;
   font-family: Inconsolata, monospace;
-  font-size: 14px;
+  font-size: 11px;
   font-weight: bold;
   opacity: .6;
   color: black;

--- a/src/components/PrimaryMap.css
+++ b/src/components/PrimaryMap.css
@@ -292,7 +292,7 @@
   margin: 0 auto;
   border: none;
   font-family: Inconsolata, monospace;
-  font-size: 9px;
+  font-size: 14px;
   font-weight: bold;
   opacity: .6;
   color: black;


### PR DESCRIPTION
Increasing the font size of the scale bar control at the bottom of the map, for improved readability. 