### PR TITLE
Update Overlay Anchor

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -907,9 +907,9 @@ export class PrimaryMap extends React.Component<Props, State> {
       dataProjection: WGS84,
       featureProjection: WEB_MERCATOR,
     })
-    const center = extent.getCenter(calculateExtent(feature.getGeometry()))
+    const anchor = extent.getTopRight(calculateExtent(feature.getGeometry()))
     features.push(feature)
-    this.featureDetailsOverlay.setPosition(center)
+    this.featureDetailsOverlay.setPosition(anchor)
   }
 }
 


### PR DESCRIPTION
The image search tooltip anchor used to spawn at the center of a search image. This would obscure the image partially. This change moves the anchor point of the tooltip to the top right of the search result frame, which allows the user to see the entire image. 