### PR TITLE
Show pointer cursor when hovering over divot outboard.

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -484,12 +484,13 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.map.forEachFeatureAtPixel(event.pixel, (feature) => {
       switch (feature.get(KEY_TYPE)) {
         case TYPE_DIVOT_INBOARD:
+        case TYPE_DIVOT_OUTBOARD:
         case TYPE_JOB:
         case TYPE_SCENE:
           foundFeature = true
           return true
       }
-    }, { layerFilter: l => l === this.frameLayer || l === this.imageryLayer })
+    }, { layerFilter: l => l === this.frameLayer || l === this.imageryLayer || l === this.pinLayer })
 
     if (foundFeature) {
       this.refs.container.classList.add(styles.isHoveringFeature)


### PR DESCRIPTION
Hovering the mouse over a divot outboard should now show a pointer, clearly indicating that it's clickable.