### PR TITLE
Highlight status label in Jobs list with colors matching divot.

### DIFF
--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -65,7 +65,6 @@
   border-radius: 1px;
   padding: 0 6px;
   border: 1px solid;
-  margin-bottom: 4px;
 }
 
 .submitted .status,
@@ -106,10 +105,6 @@
   background-color: hsla(0, 0%, 70%, 0.3);
 }
 
-.timedOut {
-  composes: failed;
-}
-
 /* =========================================================================
    Details
    ========================================================================= */
@@ -122,11 +117,12 @@
   flex: 1;
   cursor: default;
   word-break: break-all;
+  padding: .25em 0;
 }
 
 .title {
   composes: buffered-container;
-  margin: .5em 0;
+  margin: .3em 0 .5em;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -141,10 +137,6 @@
   transform: rotate(0deg);
   transform-origin: .4em .5em;
   transition: transform .15s ease-in-out;
-}
-
-.failed .caret {
-  color: white;
 }
 
 .isExpanded .caret {
@@ -170,6 +162,7 @@
   composes: buffered-container;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   font-size: 14px;
 }
 
@@ -187,10 +180,6 @@
   max-height: 0;
   background-color: rgba(0, 0, 0, .04);
   transition: max-height .15s ease-in-out;
-}
-
-.failed .metadata {
-  background-color: rgba(0, 0, 0, 0.12);
 }
 
 .metadata dl {
@@ -243,11 +232,6 @@
   font-size: 1em;
   font-weight: normal;
   font-family: inherit;
-}
-
-.failed .removeToggle button {
-  background-color: white;
-  padding: .5em;
 }
 
 .removeToggle button:hover {

--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -20,11 +20,7 @@
   --border-radius: 6px;
   --padding-size: 15px;
   --bgcolor-active: hsl(203, 100%, 94%);
-  --bgcolor-failed: var(--COLOR_RED);
-  --bgcolor-cancelled: var(--COLOR_GREY);
   --bordercolor-active: hsla(201, 100%, 50%, 0.27);
-  --bordercolor-cancelled: var(--COLOR_GREY);
-  --bordercolor-failed: hsla(344, 100%, 34%, 0.46);
   --control-bgcolor: var(--COLOR_CONTROL);
   --control-bgcolor-hover: var(--COLOR_BRAND_DARK);
   /* --header-bgcolor-hover: color(var(--COLOR_CONTROL_LIGHT) alpha(4%)); */
@@ -63,31 +59,55 @@
   color: var(--control-bgcolor-hover);
 }
 
-.succeeded {}
-
-.running {}
-
-.failed {
-  background-color: var(--bgcolor-failed);
-  color: white;
-  border-color: var(--bordercolor-failed);
+.status {
+  font-size: 12px;
+  color: black;
+  border-radius: 1px;
+  padding: 0 6px;
+  border: 1px solid;
+  margin-bottom: 4px;
 }
 
-.failed h3 {
-  color: inherit;
+.submitted .status,
+.activating .status {
+  border-color: hsl(300, 100%, 74%);
+  background-color: hsla(300, 100%, 74%, 0.3);
+}
+
+.active .status {
+  border-color: hsl(200, 94%, 54%);
+  background-color: hsla(200, 94%, 54%, 0.3);
+}
+
+.inactive .status {
+  border-color: hsl(0, 0%, 50%);
+  background-color: hsla(0, 0%, 50%, 0.3);
+}
+
+.pending .status,
+.running .status {
+  border-color: hsl(48, 94%, 54%);
+  background-color: hsla(48, 94%, 54%, 0.3);
+}
+
+.succeeded .status {
+  border: none;
+}
+
+.timedOut .status,
+.failed .status,
+.error .status {
+  border-color: hsl(349, 100%, 60%);
+  background-color: hsla(349, 100%, 60%, 0.3);
+}
+
+.cancelled .status {
+  border-color: hsl(0, 0%, 70%);
+  background-color: hsla(0, 0%, 70%, 0.3);
 }
 
 .timedOut {
   composes: failed;
-}
-
-.cancelled {
-  background-color: var(--bgcolor-cancelled);
-  border-color: var(--bordercolor-cancelled);
-}
-
-.activating {
-  border-color: var(--bordercolor-active);
 }
 
 /* =========================================================================

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -29,6 +29,8 @@ import {
   STATUS_TIMED_OUT,
   STATUS_CANCELLED,
   STATUS_ACTIVATING,
+  STATUS_PENDING,
+  STATUS_SUBMITTED,
 } from '../constants'
 
 interface Props {
@@ -192,11 +194,13 @@ export class JobStatus extends React.Component<Props, State> {
   private get _classForStatus() {
     switch (this.props.job.properties.status) {
       case STATUS_SUCCESS: return styles.succeeded
+      case STATUS_PENDING: return styles.pending
       case STATUS_RUNNING: return styles.running
       case STATUS_TIMED_OUT: return styles.timedOut
       case STATUS_ERROR: return styles.failed
       case STATUS_CANCELLED: return styles.cancelled
       case STATUS_ACTIVATING: return styles.activating
+      case STATUS_SUBMITTED: return styles.submitted
       default: return ''
     }
   }

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -79,6 +79,7 @@ import {
   STATUS_FAIL,
   STATUS_INACTIVE,
   STATUS_PENDING,
+  STATUS_SUBMITTED,
   STATUS_ACTIVATING,
   STATUS_RUNNING,
   STATUS_SUCCESS,
@@ -1276,6 +1277,7 @@ function generateSelectInteraction(...layers) {
 function getColorForStatus(status) {
   switch (status) {
     case STATUS_ACTIVE: return 'hsl(200, 94%, 54%)'
+    case STATUS_SUBMITTED:
     case STATUS_ACTIVATING: return 'hsl(300, 100%, 74%)'
     case STATUS_INACTIVE: return 'hsl(0, 0%, 50%)'
     case STATUS_PENDING:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const STATUS_PENDING = 'Pending'
 export const STATUS_INACTIVE = 'Inactive'
 export const STATUS_CANCELLED = 'Cancelled'
 export const STATUS_ACTIVATING = 'Activating'
+export const STATUS_SUBMITTED = 'Submitted'
 
 export const SOURCE_DEFAULT = 'rapideye'
 


### PR DESCRIPTION
The colors behind the status labels should match the divot colors (minus some alpha), with the exception of the "Success" status which has no background or border to prevent too much visual noise in the list.

This should also remove the intense red background for failed jobs, and instead just show a red background behind the status label.

![selection_027](https://user-images.githubusercontent.com/3220897/44488010-8c644500-a60c-11e8-9d21-e05b44bdc8ba.png)
![selection_028](https://user-images.githubusercontent.com/3220897/44488013-8e2e0880-a60c-11e8-9e44-d371ed475d85.png)
