### PR TITLE
Update Border Colors

### DIFF
--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -21,6 +21,10 @@
   --padding-size: 15px;
   --bgcolor-active: hsl(203, 100%, 94%);
   --bordercolor-active: hsla(201, 100%, 50%, 0.27);
+  --bordercolor-submitted: hsla(300, 100%, 74%, 0.3);
+  --bordercolor-running: hsla(48, 94%, 54%, 0.3);
+  --bordercolor-failed: hsla(349, 100%, 60%, 0.3);
+  --bordercolor-timedOut: hsla(0, 0%, 70%, 0.3);
   --control-bgcolor: var(--COLOR_CONTROL);
   --control-bgcolor-hover: var(--COLOR_BRAND_DARK);
   /* --header-bgcolor-hover: color(var(--COLOR_CONTROL_LIGHT) alpha(4%)); */
@@ -57,6 +61,22 @@
   border-left: 10px solid var(--bordercolor-active);
   background-color: var(--bgcolor-active);
   color: var(--control-bgcolor-hover);
+}
+
+.isActive.failed,
+.isActive.error,
+.isActive.timedOut {
+  border-left: 10px solid var(--bordercolor-failed);
+}
+
+.isActive.running,
+.isActive.pending {
+  border-left: 10px solid var(--bordercolor-running);
+}
+
+.isActive.submitted,
+.isActive.activating {
+  border-left: 10px solid var(--bordercolor-submitted);
 }
 
 .status {


### PR DESCRIPTION
I liked the colored status labels so much that I extended that color to the selected Job border color.

![image](https://user-images.githubusercontent.com/3855282/44526054-d272e480-a6b0-11e8-8054-b03ec50fc83a.png)

![image](https://user-images.githubusercontent.com/3855282/44526059-d6066b80-a6b0-11e8-9cd5-0ac66ab9c45a.png)

![image](https://user-images.githubusercontent.com/3855282/44526064-d9015c00-a6b0-11e8-8632-7d816fe2d4c9.png)

I definitely don't want to overdo the colors, but this might be a nice touch. If it's too much, we can just close this PR. 