### PR TITLE
Display Error Details

### DIFF
--- a/beachfront.d.ts
+++ b/beachfront.d.ts
@@ -47,6 +47,7 @@ declare namespace beachfront {
       extras: any
       compute_mask: boolean
       type: 'JOB'
+      errorDetails: string
     }
 
   }

--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -100,6 +100,10 @@
   background-color: hsla(349, 100%, 60%, 0.3);
 }
 
+.errorDetails {
+  color: hsl(349, 100%, 60%);
+}
+
 .cancelled .status {
   border-color: hsl(0, 0%, 70%);
   background-color: hsla(0, 0%, 70%, 0.3);

--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -100,10 +100,6 @@
   background-color: hsla(349, 100%, 60%, 0.3);
 }
 
-.errorDetails {
-  color: hsl(349, 100%, 60%);
-}
-
 .cancelled .status {
   border-color: hsl(0, 0%, 70%);
   background-color: hsla(0, 0%, 70%, 0.3);
@@ -213,6 +209,10 @@
 .metadata dd {
   flex: 1 calc(70% - 14px); /* Not working, but not harming? */
   word-break: break-all;
+}
+
+.errorDetails {
+  color: hsl(349, 100%, 60%);
 }
 
 .isExpanded .metadata {

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -74,6 +74,7 @@ export class JobStatus extends React.Component<Props, State> {
 
   render() {
     const { id, properties } = this.props.job
+    const hasError = properties.errorDetails ? true : false
 
     return (
       <li className={`${styles.root} ${this.aggregatedClassNames}`}>
@@ -113,12 +114,8 @@ export class JobStatus extends React.Component<Props, State> {
                 <dd>{properties.algorithm_name}</dd>
                 <dt>Scene ID</dt>
                 <dd>{normalizeSceneId(properties.scene_id)}</dd>
-                { properties.errorDetails && (
-                  <div>
-                    <dt className={styles.errorDetails}>Error</dt>
-                    <dd>{properties.errorDetails}</dd>
-                  </div>
-                )}
+                {hasError && (<dt>Error</dt>)}
+                {hasError && (<dd className={styles.errorDetails}>{properties.errorDetails}</dd>)}
                 {/*<dt>Captured On</dt>
                 <dd>{moment(properties.captured_on).utc().format('MM/DD/YYYY HH:mm z')}</dd>
                 <dt>Sensor</dt>

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -113,9 +113,9 @@ export class JobStatus extends React.Component<Props, State> {
                 <dd>{properties.algorithm_name}</dd>
                 <dt>Scene ID</dt>
                 <dd>{normalizeSceneId(properties.scene_id)}</dd>
-                {properties.errorDetails && (
+                { properties.errorDetails && (
                   <div>
-                    <dt>Error</dt>
+                    <dt className={styles.errorDetails}>Error</dt>
                     <dd>{properties.errorDetails}</dd>
                   </div>
                 )}

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -113,6 +113,12 @@ export class JobStatus extends React.Component<Props, State> {
                 <dd>{properties.algorithm_name}</dd>
                 <dt>Scene ID</dt>
                 <dd>{normalizeSceneId(properties.scene_id)}</dd>
+                {properties.errorDetails && (
+                  <div>
+                    <dt>Error</dt>
+                    <dd>{properties.errorDetails}</dd>
+                  </div>
+                )}
                 {/*<dt>Captured On</dt>
                 <dd>{moment(properties.captured_on).utc().format('MM/DD/YYYY HH:mm z')}</dd>
                 <dt>Sensor</dt>

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -116,10 +116,6 @@ export class JobStatus extends React.Component<Props, State> {
                 <dd>{normalizeSceneId(properties.scene_id)}</dd>
                 {hasError && (<dt>Error</dt>)}
                 {hasError && (<dd className={styles.errorDetails}>{properties.errorDetails}</dd>)}
-                {/*<dt>Captured On</dt>
-                <dd>{moment(properties.captured_on).utc().format('MM/DD/YYYY HH:mm z')}</dd>
-                <dt>Sensor</dt>
-                <dd>{properties.scene_sensor_name}</dd>*/}
               </dl>
               <div className={styles.removeToggle}>
                 <button onClick={this.handleForgetToggle}>


### PR DESCRIPTION
Currently when a job fails, there is no reporting of why the job failed in the UI. There are some user-friendly messages that are now available in the GeoJSON that can be reported. This PR adds a row in the metadata element in the Jobs list that describes the error.

![image](https://user-images.githubusercontent.com/3855282/44602307-3a0e5a00-a7ad-11e8-8ded-836b28fd3752.png)

For most existing jobs, this default value "error" was all that was committed to the database. However, due to a paired up PR in BF-API ( https://github.com/venicegeo/bf-api/pull/288 ) we are now conveying the appropriate error message from the algorithm. This means that all failures going forward should have some user-friendly statement that describes the failure. 