### PR TITLE
Fix perma algorithm error

### DIFF
--- a/src/components/CreateJob.tsx
+++ b/src/components/CreateJob.tsx
@@ -174,7 +174,10 @@ export class CreateJob extends React.Component<Props, State> {
   }
 
   private handleCreateJob(algorithm) {
-    this.setState({ isCreating: true })
+    this.setState({
+      isCreating: true,
+      algorithmError: '',
+    })
 
     createJob({
       algorithmId: algorithm.id,

--- a/src/components/CreateJob.tsx
+++ b/src/components/CreateJob.tsx
@@ -58,7 +58,6 @@ interface State {
   isCreating?: boolean
   computeMask?: boolean
   name?: string
-  shouldAutogenerateName?: boolean
   algorithmError?: any
 }
 
@@ -77,7 +76,6 @@ export class CreateJob extends React.Component<Props, State> {
       isCreating: false,
       computeMask: true,
       name: props.selectedScene ? normalizeSceneId(props.selectedScene.id) : '',
-      shouldAutogenerateName: true,
       algorithmError: '',
     }
 
@@ -89,12 +87,17 @@ export class CreateJob extends React.Component<Props, State> {
     this.handleSearchSourceChange = this.handleSearchSourceChange.bind(this)
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    if (this.state.shouldAutogenerateName
-      && nextProps.selectedScene
-      && nextProps.selectedScene !== this.props.selectedScene
-    ) {
-      this.setState({ name: normalizeSceneId(nextProps.selectedScene.id) })
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.selectedScene !== prevProps.selectedScene) {
+      // Set the default name using the scene id.
+      if (this.props.selectedScene && !this.state.name) {
+        this.setState({ name: normalizeSceneId(this.props.selectedScene.id) })
+      }
+
+      // Reset the algorithm error.
+      if (this.state.algorithmError) {
+        this.setState({ algorithmError: '' })
+      }
     }
   }
 
@@ -209,6 +212,6 @@ export class CreateJob extends React.Component<Props, State> {
   }
 
   private handleNameChange(name) {
-    this.setState({ name, shouldAutogenerateName: !name })
+    this.setState({ name })
   }
 }


### PR DESCRIPTION
Fixes an issue where the algorithm error message could only be cleared by switching away from **Create Job** and switching back. It should now disappear as soon as your selection is changed, or when you re-run the algorithm.

**Note:** I also cleaned up some code that was setting the default job name. It seemed to be more complex than it needed to be.

![selection_038](https://user-images.githubusercontent.com/3220897/44697996-080e2980-aa33-11e8-8508-5e8755bc95e3.png)
