### PR TITLE
Expand/Shrink selected job details on title click. Chevron padding.

### DIFF
--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -152,9 +152,9 @@
 .caret {
   width: 1em;
   color: rgba(0,0,0, .3);
-  margin-top: 2px;
+  padding: 3px;
   transform: rotate(0deg);
-  transform-origin: .4em .5em;
+  transform-origin: .5em .65em;
   transition: transform .15s ease-in-out;
   cursor: pointer;
 }

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -37,6 +37,7 @@ interface Props {
   className?: string
   isActive: boolean
   job: beachfront.Job
+  selectedFeature: beachfront.Job | beachfront.Scene
   onSelectJob(job: beachfront.Job)
   onForgetJob(job: beachfront.Job)
   onNavigate(loc: { pathname: string, search: string, hash: string })
@@ -62,14 +63,14 @@ export class JobStatus extends React.Component<Props, State> {
       isRemoving: false,
     }
 
-    this.emitOnSelectJob        = this.emitOnSelectJob.bind(this)
+    this.jobTitleClick          = this.jobTitleClick.bind(this)
     this.emitOnForgetJob        = this.emitOnForgetJob.bind(this)
     this.handleDownloadComplete = this.handleDownloadComplete.bind(this)
     this.handleDownloadError    = this.handleDownloadError.bind(this)
     this.handleDownloadProgress = this.handleDownloadProgress.bind(this)
     this.handleDownloadStart    = this.handleDownloadStart.bind(this)
-    this.handleExpansionToggle  = this.handleExpansionToggle.bind(this)
     this.handleForgetToggle     = this.handleForgetToggle.bind(this)
+    this.toggleExpansion        = this.toggleExpansion.bind(this)
   }
 
   render() {
@@ -93,9 +94,9 @@ export class JobStatus extends React.Component<Props, State> {
             <h3 className={styles.title}>
               <i
                 className={`fa fa-chevron-right ${styles.caret}`}
-                onClick={this.handleExpansionToggle}
+                onClick={this.toggleExpansion}
               />
-              <span onClick={this.emitOnSelectJob}>
+              <span onClick={this.jobTitleClick}>
                 {segmentIfNeeded(properties.name)}
               </span>
             </h3>
@@ -211,7 +212,11 @@ export class JobStatus extends React.Component<Props, State> {
     }
   }
 
-  private emitOnSelectJob() {
+  private jobTitleClick() {
+    if (this.props.selectedFeature === this.props.job) {
+      this.toggleExpansion()
+    }
+
     this.props.onSelectJob(this.props.job)
   }
 
@@ -235,15 +240,15 @@ export class JobStatus extends React.Component<Props, State> {
     this.setState({ isDownloading: false })
   }
 
-  private handleExpansionToggle() {
+  private handleForgetToggle() {
+    this.setState({ isRemoving: !this.state.isRemoving })
+  }
+
+  private toggleExpansion() {
     this.setState({
       isExpanded: !this.state.isExpanded,
       isRemoving: false,
     })
-  }
-
-  private handleForgetToggle() {
-    this.setState({ isRemoving: !this.state.isRemoving })
   }
 }
 

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -70,6 +70,7 @@ export class JobStatusList extends React.Component<Props, void> {
               onNavigate={this.props.onNavigateToJob}
               onForgetJob={this.props.onForgetJob}
               onSelectJob={this.props.onSelectJob}
+              selectedFeature={this.props.selectedFeature}
             />
           ))}
         </ul>


### PR DESCRIPTION
If you click the title of the currently selected job it should now behave the same as if you click the chevron. The chevron click target should be slightly larger now as well, with more centered rotation.