### PR TITLE
Clear imagery search error when bbox changes.

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -438,7 +438,10 @@ export class Application extends React.Component<Props, State> {
   }
 
   private handleBoundingBoxChange(bbox) {
-    this.setState({ bbox })
+    this.setState({
+      bbox,
+      searchError: null,
+    })
   }
 
   private handleCatalogApiKeyChange(catalogApiKey) {


### PR DESCRIPTION
This fixes an inconsistency where the imagery search error would disappear if you cleared your bbox, but not if you redrew it without clearing. The error should disappear in both cases now.

![selection_039](https://user-images.githubusercontent.com/3220897/44847834-920feb00-ac09-11e8-8251-dc7d5541512d.png)
