### PR TITLE
Only render search imagery and bbox while creating a job.

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -198,6 +198,7 @@ export class Application extends React.Component<Props, State> {
           startTour={this.startTour}
         />
         <PrimaryMap
+          activeRoute={this.state.route}
           bbox={this.state.bbox}
           catalogApiKey={this.state.catalogApiKey}
           detections={this.detectionsForCurrentMode}
@@ -578,12 +579,16 @@ export class Application extends React.Component<Props, State> {
     history.pushState(null, null, route.href)
 
     // Update selected feature if needed.
-    let selectedFeature = 'selectedFeature' in loc
-      ? loc.selectedFeature
-      : this.state.selectedFeature
-
+    let selectedFeature = this.state.selectedFeature
     if (route.jobIds.length) {
       selectedFeature = this.state.jobs.records.find(j => route.jobIds.includes(j.id))
+    } else if ('selectedFeature' in loc) {
+      selectedFeature = loc.selectedFeature
+    } else if (this.state.route.pathname === '/create-job' && route.pathname !== '/create-job') {
+      // If we're navigating away from Create Job and have search imagery selected, clear the selection.
+      if (selectedFeature && selectedFeature.properties.type !== TYPE_JOB) {
+        selectedFeature = null
+      }
     }
 
     /* TODO: Okay?

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -116,6 +116,7 @@ export const MODE_PRODUCT_LINES = 'MODE_PRODUCT_LINES'
 export const MODE_SELECT_IMAGERY = 'MODE_SELECT_IMAGERY'
 
 interface Props {
+  activeRoute: { pathname: string, search: string, hash: string }
   bbox: number[]
   catalogApiKey:      string
   detections:         (beachfront.Job | beachfront.ProductLine)[]
@@ -225,6 +226,8 @@ export class PrimaryMap extends React.Component<Props, State> {
   }
 
   componentDidUpdate(previousProps: Props, previousState: State) {
+    const routeChanged = previousProps.activeRoute !== this.props.activeRoute
+
     if (!this.props.selectedFeature) {
       this.clearSelection()
     }
@@ -242,7 +245,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.renderHighlight()
     }
 
-    if (previousProps.imagery !== this.props.imagery) {
+    if (previousProps.imagery !== this.props.imagery || routeChanged) {
       this.renderImagery()
     }
 
@@ -255,7 +258,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateMapSize()
     }
 
-    if (previousProps.bbox !== this.props.bbox) {
+    if (previousProps.bbox !== this.props.bbox || routeChanged) {
       this.renderImagerySearchBbox()
     }
 
@@ -739,6 +742,10 @@ export class PrimaryMap extends React.Component<Props, State> {
     source.setAttributions(undefined)
     source.clear()
 
+    if (this.props.activeRoute.pathname !== '/create-job') {
+      return
+    }
+
     if (imagery) {
       const features = reader.readFeatures(imagery.images, {
         dataProjection: WGS84,
@@ -780,7 +787,7 @@ export class PrimaryMap extends React.Component<Props, State> {
   private renderImagerySearchBbox() {
     this.clearDraw()
     const bbox = deserializeBbox(this.props.bbox)
-    if (!bbox) {
+    if (!bbox || this.props.activeRoute.pathname !== '/create-job') {
       return
     }
 


### PR DESCRIPTION
Search imagery and bbox associated with Create Job should only render when you're on the Create Job page. However, the state should be saved so that if you return to Create Job you should get your bbox and imagery back.

**Note:**
There's an existing bug I noticed unrelated to these changes where if you have a job selected on the Jobs page then navigate to Create Job, it will deselect the job from the list and hide its vector data yet still render its imagery and show the job as selected on the map. I've noted it and will fix it separately.

![selection_040](https://user-images.githubusercontent.com/3220897/44853063-ca1f2a00-ac19-11e8-8b52-5510f9bda8e3.png)
![selection_041](https://user-images.githubusercontent.com/3220897/44853068-cc818400-ac19-11e8-8e58-66516ac33789.png)
