### PR TITLE
Improve Job Selection Scroll

### DIFF
--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -80,7 +80,19 @@ export class JobStatusList extends React.Component<Props, void> {
 
   private scrollToSelectedJob() {
     const row = document.querySelector(`.${jobStatusStyles.isActive}`)
-    if (row) { row.scrollIntoView({ behavior: 'smooth' }) }
+    if (row) { 
+      const offset = [
+        '.JobStatusList-root header',
+        '.ClassificationBanner-root',
+      ].reduce((rc, s) => rc + document.querySelector(s).clientHeight, 0)
+
+      const box = row.getBoundingClientRect()
+      const height = window.innerHeight || document.documentElement.clientHeight
+
+      if (Math.floor(box.top) <= offset || box.bottom > height - row.clientHeight) {
+        row.scrollIntoView({ behavior: 'smooth' })
+      }
+    }
   }
 
 }

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -90,7 +90,7 @@ export class JobStatusList extends React.Component<Props, void> {
       const height = window.innerHeight || document.documentElement.clientHeight
 
       if (Math.floor(box.top) <= offset || box.bottom > height - row.clientHeight) {
-        row.scrollIntoView({ behavior: 'smooth' })
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
       }
     }
   }


### PR DESCRIPTION
Currently when selecting Jobs in the Jobs list, the list scrolls even when you click on a Job list item that is currently displayed in the viewport. This is mildly annoying behavior. 

This fix will only cause an autoscroll if the selected Job row is not in the viewport. So now this auto-scroll should only occur is the Job is selected from the map and that job is not visible in the current list.