### PR TITLE
Fix Cycle Selections and Layer Styles

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -248,7 +248,6 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (previousProps.frames !== this.props.frames) {
       this.renderFrames()
       this.renderPins()
-      this.updateStyles()
     }
 
     if (previousProps.imagery !== this.props.imagery || routeChanged) {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -226,7 +226,7 @@ export class PrimaryMap extends React.Component<Props, State> {
   }
 
   componentDidUpdate(previousProps: Props, previousState: State) {
-    const routeChanged = previousProps.activeRoute !== this.props.activeRoute
+    const routeChanged = previousProps.activeRoute.pathname !== this.props.activeRoute.pathname
 
     if (!this.props.selectedFeature) {
       this.clearSelection()

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -248,6 +248,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (previousProps.frames !== this.props.frames) {
       this.renderFrames()
       this.renderPins()
+      this.updateStyles()
     }
 
     if (previousProps.imagery !== this.props.imagery || routeChanged) {
@@ -279,6 +280,8 @@ export class PrimaryMap extends React.Component<Props, State> {
       (previousState.isMeasuring !== this.state.isMeasuring)) {
       this.updateInteractions()
     }
+
+    this.updateStyles()
   }
 
   render() {
@@ -718,6 +721,103 @@ export class PrimaryMap extends React.Component<Props, State> {
     })
   }
 
+  private updateStyles() {
+    const isClose = this.map.getView().getResolution() < RESOLUTION_CLOSE
+
+    const frames = this.frameLayer.getSource().getFeatures()
+    frames.forEach(feature => {
+      const isSelected = (this.props.selectedFeature && this.props.selectedFeature.id === feature.getId())
+
+      feature.setStyle(new Style({
+        stroke: new Stroke({
+          color: isSelected ? 'black' : 'rgba(0, 0, 0, .4)',
+          lineDash: isSelected ? undefined : [10, 10],
+          width: isSelected ? 2 : 1,
+        }),
+        fill: new Fill({
+          color: isClose || isSelected ? 'transparent' : 'hsla(202, 100%, 85%, 0.5)',
+        }),
+      }))
+    })
+
+    const pins = this.pinLayer.getSource().getFeatures()
+    pins.forEach(feature => {
+      const isSelected = (this.props.selectedFeature && this.props.selectedFeature.id === feature.get(KEY_OWNER_ID))
+      feature.setStyle(() => {
+        switch (feature.get(KEY_TYPE)) {
+          case TYPE_DIVOT_INBOARD:
+            return new Style({
+              image: new RegularShape({
+                angle: Math.PI / 4,
+                points: 4,
+                radius: 5,
+                fill: new Fill({
+                  color: 'black',
+                }),
+              }),
+            })
+          case TYPE_DIVOT_OUTBOARD:
+            return new Style({
+              image: new RegularShape({
+                angle: Math.PI / 4,
+                points: 4,
+                radius: isSelected ? 15 : 10,
+                stroke: new Stroke({
+                  color: 'black',
+                  width: isSelected ? 2 : 1,
+                }),
+                fill: new Fill({
+                  color: getColorForStatus(feature.get(KEY_STATUS)),
+                }),
+              }),
+              zIndex: isSelected ? 1 : undefined,
+            })
+          case TYPE_STEM:
+            return new Style({
+              stroke: new Stroke({
+                color: 'black',
+                width: 1,
+              }),
+            })
+          case TYPE_LABEL_MAJOR:
+            return new Style({
+              text: new Text({
+                fill: new Fill({
+                  color: isClose || isSelected ? 'black' : 'transparent',
+                }),
+                offsetX: 13,
+                offsetY: 1,
+                font: 'bold 17px Catamaran, Verdana, sans-serif',
+                text: feature.get(KEY_NAME).toUpperCase(),
+                textAlign: 'left',
+                textBaseline: 'middle',
+              }),
+            })
+          case TYPE_LABEL_MINOR:
+            const name = feature.get(KEY_NAME)
+            const sceneId = normalizeSceneId(feature.get(KEY_SCENE_ID))
+
+            return new Style({
+              text: new Text({
+                fill: new Fill({
+                  color: isClose ? 'rgba(0,0,0,.6)' : 'transparent',
+                }),
+                offsetX: 13,
+                offsetY: 15,
+                font: '11px Verdana, sans-serif',
+                text: ([
+                  feature.get(KEY_STATUS),
+                  sceneId !== name ? sceneId : null,
+                ].filter(Boolean)).join(' // ').toUpperCase(),
+                textAlign: 'left',
+                textBaseline: 'middle',
+              }),
+            })
+        }
+      })
+    })
+  }
+
   private renderHighlight() {
     const source = this.highlightLayer.getSource()
     source.clear()
@@ -926,21 +1026,6 @@ export class PrimaryMap extends React.Component<Props, State> {
   private generateFrameLayer() {
     const layer = new VectorLayer({
       source: new VectorSource(),
-      style: (feature: Feature, resolution: number) => {
-        const isClose = resolution < RESOLUTION_CLOSE
-        const isSelected = (this.props.selectedFeature && this.props.selectedFeature.id === feature.getId())
-
-        return new Style({
-          stroke: new Stroke({
-            color: isSelected ? 'black' : 'rgba(0, 0, 0, .4)',
-            lineDash: isSelected ? undefined : [10, 10],
-            width: isSelected ? 2 : 1,
-          }),
-          fill: new Fill({
-            color: isClose || isSelected ? 'transparent' : 'hsla(202, 100%, 85%, 0.5)',
-          }),
-        })
-      },
     })
 
     return layer
@@ -949,81 +1034,6 @@ export class PrimaryMap extends React.Component<Props, State> {
   private generatePinLayer() {
     const layer = new VectorLayer({
       source: new VectorSource(),
-      style: (feature: Feature, resolution: number) => {
-        const isClose = resolution < RESOLUTION_CLOSE
-        const isSelected = (this.props.selectedFeature && this.props.selectedFeature.id === feature.get(KEY_OWNER_ID))
-
-        switch (feature.get(KEY_TYPE)) {
-          case TYPE_DIVOT_INBOARD:
-            return new Style({
-              image: new RegularShape({
-                angle: Math.PI / 4,
-                points: 4,
-                radius: 5,
-                fill: new Fill({
-                  color: 'black',
-                }),
-              }),
-            })
-          case TYPE_DIVOT_OUTBOARD:
-            return new Style({
-              image: new RegularShape({
-                angle: Math.PI / 4,
-                points: 4,
-                radius: isSelected ? 15 : 10,
-                stroke: new Stroke({
-                  color: 'black',
-                  width: isSelected ? 2 : 1,
-                }),
-                fill: new Fill({
-                  color: getColorForStatus(feature.get(KEY_STATUS)),
-                }),
-              }),
-              zIndex: isSelected ? 1 : undefined,
-            })
-          case TYPE_STEM:
-            return new Style({
-              stroke: new Stroke({
-                color: 'black',
-                width: 1,
-              }),
-            })
-          case TYPE_LABEL_MAJOR:
-            return new Style({
-              text: new Text({
-                fill: new Fill({
-                  color: isClose || isSelected ? 'black' : 'transparent',
-                }),
-                offsetX: 13,
-                offsetY: 1,
-                font: 'bold 17px Catamaran, Verdana, sans-serif',
-                text: feature.get(KEY_NAME).toUpperCase(),
-                textAlign: 'left',
-                textBaseline: 'middle',
-              }),
-            })
-          case TYPE_LABEL_MINOR:
-            const name = feature.get(KEY_NAME)
-            const sceneId = normalizeSceneId(feature.get(KEY_SCENE_ID))
-
-            return new Style({
-              text: new Text({
-                fill: new Fill({
-                  color: isClose ? 'rgba(0,0,0,.6)' : 'transparent',
-                }),
-                offsetX: 13,
-                offsetY: 15,
-                font: '11px Verdana, sans-serif',
-                text: ([
-                  feature.get(KEY_STATUS),
-                  sceneId !== name ? sceneId : null,
-                ].filter(Boolean)).join(' // ').toUpperCase(),
-                textAlign: 'left',
-                textBaseline: 'middle',
-              }),
-            })
-        }
-      },
     })
 
     layer.setZIndex(3)

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -245,6 +245,11 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.renderHighlight()
     }
 
+    if (previousProps.frames !== this.props.frames) {
+      this.renderFrames()
+      this.renderPins()
+    }
+
     if (previousProps.imagery !== this.props.imagery || routeChanged) {
       this.renderImagery()
     }
@@ -274,9 +279,6 @@ export class PrimaryMap extends React.Component<Props, State> {
       (previousState.isMeasuring !== this.state.isMeasuring)) {
       this.updateInteractions()
     }
-
-    this.renderFrames()
-    this.renderPins()
   }
 
   render() {
@@ -941,8 +943,6 @@ export class PrimaryMap extends React.Component<Props, State> {
       },
     })
 
-    layer.setZIndex(3)
-
     return layer
   }
 
@@ -1026,7 +1026,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       },
     })
 
-    layer.setZIndex(4)
+    layer.setZIndex(3)
 
     return layer
   }
@@ -1280,12 +1280,6 @@ function generateSelectInteraction(...layers) {
     ),
     style: (feature: Feature) => {
       switch (feature.get(KEY_TYPE)) {
-        case TYPE_JOB:
-          /*
-            Don't render the selection for jobs, since they render on top of the divots. We'll render
-            their outlines in the frame layer instead.
-          */
-          return new Style()
         default:
           return new Style({
             stroke: new Stroke({


### PR DESCRIPTION
There was a bug that was introduced where clicking repeatedly on a single point in the map would no longer cycle through all of the selections at that point. 

This was due to the aggressive re-rendering of both the Job results and the imagery search results. I updated the logic where the route name was compared, to ensure that this wasn't getting called too aggressively.

Additionally, because I removed these extra calls to re-rendering, I had to re-work the way we update the style of the Divots upon selection. Because blowing away the old features broke the multiple selections, I had to change that logic to update the style of the existing feature instead of re-creating. As such, I moved all this logic into a separate method that just updates the styles. This is an inexpensive method that we can call on update as needed without worrying about side effects. 

Things to verify on this PR:

1) Clicking on a point in the map that contains multiple overlapping jobs should cycle between the jobs
2) Clicking on a point in the map that contains multiple overlapping image results should cycle between those results
3) The Jobs divot should expand and contract when selected/deselected, and the divot text should appear when selected.
