### PR TITLE
Update Job Name on Scene Change

### DIFF
--- a/src/components/CreateJob.tsx
+++ b/src/components/CreateJob.tsx
@@ -90,7 +90,7 @@ export class CreateJob extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props) {
     if (this.props.selectedScene !== prevProps.selectedScene) {
       // Set the default name using the scene id.
-      if (this.props.selectedScene && !this.state.name) {
+      if (this.props.selectedScene) {
         this.setState({ name: normalizeSceneId(this.props.selectedScene.id) })
       }
 


### PR DESCRIPTION
When users create a job, the default name of that job is the scene name. However, the behavior in the code would only rename the Job if the Job name was empty (which is the default state). This meant that when browsing through Scenes to run a Job on, the name of that Job would always be the name of the first Scene selected -- unless otherwise updated by the user. This creates a scenario where there are many jobs that are not named according to their selected Scenes.

This PR changes the logic to always update the Job name when the scene has changed.

Since most jobs are _not_ named by the user at all, this makes the most sense to just rename the Job every time a new scene is selected. 