### PR TITLE
Don't show hover cursor for map features while drawing bbox.

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -483,7 +483,7 @@ export class PrimaryMap extends React.Component<Props, State> {
   }
 
   private handleMouseMove(event) {
-    if (this.state.isMeasuring) {
+    if (this.state.isMeasuring || this.props.mode === MODE_DRAW_BBOX) {
       this.refs.container.classList.remove(styles.isHoveringFeature)
       return
     }


### PR DESCRIPTION
This fixes an issue where in bbox draw mode you would still see the pointer cursor when hovering the mouse over map features, even though you couldn't click on them. Now while drawing the bbox you should no longer see any hover cursors for map features unless you're finished drawing the bbox.