### PR TITLE
Successful Detection Refresh

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -633,7 +633,6 @@ export class Application extends React.Component<Props, State> {
   }
 
   private refreshRecords() {
-    console.log('(application:refreshRecords) fetching latest jobs and product lines')
     return Promise.all([
       this.fetchJobs(),
       /*

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -208,6 +208,7 @@ export class Application extends React.Component<Props, State> {
           logout={this.logout}
           mode={this.mapMode}
           ref="map"
+          jobs={this.state.jobs.records}
           selectedFeature={this.state.selectedFeature}
           shrunk={shrunk}
           view={this.state.mapView}

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -240,13 +240,15 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.renderDetections()
     }
 
-    // This block will attempt to determine if a Job is currently selected, and has had it's status changed to a SUCCESS,
-    // in which case the detections layer in OpenLayers should be refreshed. Only perform this check on Jobs, and only
-    // refresh the layer if the Job's status has changed to success.
+    /*
+     This block will attempt to determine if a Job is currently selected, and has had it's status changed to a SUCCESS,
+     in which case the detections layer in OpenLayers should be refreshed. Only perform this check on Jobs, and only
+     refresh the layer if the Job's status has changed to success.
+    */
     const selectedJob = (this.props.selectedFeature as beachfront.Job)
     if (selectedJob) {
-      const previousJob = previousProps.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
-      const currentJob = this.props.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
+      const previousJob = previousProps.jobs.filter(j => j.properties.job_id === selectedJob.properties.job_id)[0]
+      const currentJob = this.props.jobs.filter(j => j.properties.job_id === selectedJob.properties.job_id)[0]
       if (previousJob && currentJob) {
         if ((previousJob.properties.status !== STATUS_SUCCESS) && (currentJob.properties.status === STATUS_SUCCESS)) {
           this.refreshDetections()

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -242,6 +242,9 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.renderDetections()
     }
 
+    // This block will attempt to determine if a Job is currently selected, and has had it's status changed to a SUCCESS,
+    // in which case the detections layer in OpenLayers should be refreshed. Only perform this check on Jobs, and only
+    // refresh the layer if the Job's status has changed to success.
     const selectedJob = (this.props.selectedFeature as beachfront.Job)
     if (selectedJob) {
       const previousJob = previousProps.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
@@ -966,7 +969,6 @@ export class PrimaryMap extends React.Component<Props, State> {
         }
 
         layer.setZIndex(1)
-        console.log('Created preview layer', layer)
 
         this.subscribeToLoadEvents(layer)
         this.previewLayers[f.sceneId] = layer

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -241,10 +241,10 @@ export class PrimaryMap extends React.Component<Props, State> {
 
     const selectedJob = (this.props.selectedFeature as beachfront.Job)
     if (selectedJob) {
-      const oldJob = previousProps.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
+      const previousJob = previousProps.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
       const currentJob = this.props.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
-      if (oldJob && currentJob) {
-        if ((oldJob.properties.status !== STATUS_SUCCESS) && (currentJob.properties.status === STATUS_SUCCESS)) {
+      if (previousJob && currentJob) {
+        if ((previousJob.properties.status !== STATUS_SUCCESS) && (currentJob.properties.status === STATUS_SUCCESS)) {
           this.refreshDetections()
         }
       }
@@ -623,8 +623,7 @@ export class PrimaryMap extends React.Component<Props, State> {
   private refreshDetections() {
     Object.keys(this.detectionsLayers).forEach(layerId => {
       const layer = this.detectionsLayers[layerId]
-      const source = layer.getSource()
-      source.refresh()
+      layer.getSource().refresh()
     })
   }
 

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -124,6 +124,7 @@ interface Props {
   imagery:            beachfront.ImageryCatalogPage
   isSearching:        boolean
   mode:               string
+  jobs:               beachfront.Job[]
   selectedFeature:    beachfront.Job | beachfront.Scene
   view:               MapView
   wmsUrl:             string
@@ -236,6 +237,17 @@ export class PrimaryMap extends React.Component<Props, State> {
 
     if (previousProps.detections !== this.props.detections) {
       this.renderDetections()
+    }
+
+    const selectedJob = (this.props.selectedFeature as beachfront.Job)
+    if (selectedJob) {
+      const oldJob = previousProps.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
+      const currentJob = this.props.jobs.filter(j => j.properties.job_id == selectedJob.properties.job_id)[0]
+      if (oldJob && currentJob) {
+        if ((oldJob.properties.status !== STATUS_SUCCESS) && (currentJob.properties.status === STATUS_SUCCESS)) {
+          this.refreshDetections()
+        }
+      }
     }
 
     if (previousProps.highlightedFeature !== this.props.highlightedFeature) {
@@ -606,6 +618,14 @@ export class PrimaryMap extends React.Component<Props, State> {
         duration,
       })
     }
+  }
+
+  private refreshDetections() {
+    Object.keys(this.detectionsLayers).forEach(layerId => {
+      const layer = this.detectionsLayers[layerId]
+      const source = layer.getSource()
+      source.refresh()
+    })
   }
 
   private renderDetections() {


### PR DESCRIPTION
Previously, if you had a running job selected that eventually completed, the detections vectors would not show on the map until you zoomed/panned around the map, or de-selected the Job. This is because there was no event that checked for the status of that Job.

This PR adds a check that will determine if the current Job is running, and if so, if it's status ever changes to Success -- in which case it will refresh the source for that Job's detections layer which will pull the latest vectors from GeoServer. 

Now Detection vectors will automatically show up on the map without having to pan/zoom when that job completes. 