### PR TITLE
Improve Styles Triggering

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -233,6 +233,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (previousProps.selectedFeature !== this.props.selectedFeature) {
       this.renderSelectionPreview()
       this.updateSelectedFeature()
+      this.updateStyles()
     }
 
     if (previousProps.detections !== this.props.detections) {
@@ -246,6 +247,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (previousProps.frames !== this.props.frames) {
       this.renderFrames()
       this.renderPins()
+      this.updateStyles()
     }
 
     if (previousProps.imagery !== this.props.imagery || routeChanged) {
@@ -278,7 +280,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateInteractions()
     }
 
-    this.updateStyles()
+
   }
 
   render() {


### PR DESCRIPTION
The call to updateStyles should not be unconditional, in the componentDidUpdate method. It should only be called when necessary.

It should be called when 1) the selection changes and 2) the pins/frames change.

This change will slightly reduce the amount of unnecessary calls that will occur here. 