### PR TITLE
Remove "noUnusedLocals" and "noUnusedParameters" rules from tsconfig.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
     "module": "commonjs",
     "target": "es6",
     "lib": ["dom", "es6", "es2016.array.include"],
-    "jsx": "react",
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "jsx": "react"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
I thought I'd go ahead and submit a PR for this since I've had these changes sitting locally for quite a while to avoid workflow pains without them. There shouldn't be any danger with removing them aside from the possibility of some very minor stale unused code sneaking through. That's an easy thing to cleanup from time to time though. If we want to halt Jenkins builds in the case of unused code we might be able to hook into the tslint output.