### PR TITLE
Don't render extraneous imagery polygons along meridian.

### DIFF
--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -72,6 +72,14 @@ export function search({
 
       images.features.forEach(f => {
         f.id = source + ':' + f.id
+
+        /*
+          Features that straddle the meridian will contain multipolygons that have an extraneous polygon. However,
+          only one id exists per feature which corresponds to the first polygon, so discard any extra polygons.
+        */
+        if (f.geometry.type === 'MultiPolygon') {
+          f.geometry.coordinates = f.geometry.coordinates.slice(0, 1)
+        }
       })
 
       return {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -855,6 +855,16 @@ export class PrimaryMap extends React.Component<Props, State> {
     }
 
     if (imagery) {
+      /*
+        Features that straddles the meridian will be multipolygons containing an extraneous polygon. We'll only
+        have imagery for the first polygon, so discard any others.
+      */
+      imagery.images.features.forEach(feature => {
+        if (feature.geometry.type === 'MultiPolygon') {
+          feature.geometry.coordinates = feature.geometry.coordinates.slice(0, 1)
+        }
+      })
+
       const features = reader.readFeatures(imagery.images, {
         dataProjection: WGS84,
         featureProjection: WEB_MERCATOR,

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -855,16 +855,6 @@ export class PrimaryMap extends React.Component<Props, State> {
     }
 
     if (imagery) {
-      /*
-        Features that straddles the meridian will be multipolygons containing an extraneous polygon. We'll only
-        have imagery for the first polygon, so discard any others.
-      */
-      imagery.images.features.forEach(feature => {
-        if (feature.geometry.type === 'MultiPolygon') {
-          feature.geometry.coordinates = feature.geometry.coordinates.slice(0, 1)
-        }
-      })
-
       const features = reader.readFeatures(imagery.images, {
         dataProjection: WGS84,
         featureProjection: WEB_MERCATOR,


### PR DESCRIPTION
This addresses an issue that @fsufitch had reported regarding polygons beyond the meridian that appear to have imagery associated with them, but when you click on them only imagery up to the meridian would be rendered. Here's an example of a case where this occurs...

![selection_048](https://user-images.githubusercontent.com/3220897/45250742-cb71e600-b2ee-11e8-83e5-a1269dee0d61.png)

If you click the polygon to the left of the meridian, nothing will happen - you'll still see the same preview image rendered. After looking into this a bit, it doesn't look like there's an available preview image associated with the polygon to the left of the meridian. Only one ID exists on the feature to retrieve a preview image with, however it contains multiple polygons. So I went ahead and simply discarded the irrelevant extra polygon in features along the meridian to avoid confusion. It doesn't seem like an ideal fix, but as far as I can tell it's the best that can be done unless we can somehow get multiple ids returning from Planet within a single feature or tell it to properly split meridian imagery into multiple features.

![selection_046](https://user-images.githubusercontent.com/3220897/45250772-4f2bd280-b2ef-11e8-923e-a497904662ff.png)
