### PR TITLE
Imagery Max Zoom

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -1269,6 +1269,7 @@ function generateXYZScenePreviewSource(provider, imageId, apiKey) {
     crossOrigin: 'anonymous',
     tileLoadFunction,
     url: provider.url.replace('__SCENE_ID__', imageId).replace('__API_KEY__', apiKey),
+    maxZoom: 12,
   }))
 }
 


### PR DESCRIPTION
Planet imagery only supports up to zoom level 12. Any further and errors are received (401s). 

![image](https://user-images.githubusercontent.com/3855282/45300259-d9d12500-b4db-11e8-9d2d-41bf03255de1.png)

By knowing this maximum zoom, we can update the Planet layer specifically to set the max zoom to 12. Openlayers will then only call up to this zoom level for those preview tiles.

![image](https://user-images.githubusercontent.com/3855282/45300295-f0777c00-b4db-11e8-999e-73de28d352ad.png)
