### PR TITLE
Remove multiple state calls upon deselection

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -297,7 +297,6 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateInteractions()
     }
 
-
   }
 
   render() {


### PR DESCRIPTION
This fixes the issue where clicking on a Job on the map , with the Jobs List open, will not properly scroll to the selected job. This issue can be seen on `master`.

The reason for this error is because the `componentDidUpdate`, in the JobStatusList.tsx file, is getting called twice in a row. But the state of the application after the first call (when the scroll is attempted) is not in a proper state that the scroll can be initiated -- because the job item has not been selected after that first state (because the first state is simply a deselection) - so the CSS match fails in `scrollToSelectedJob`.

This is a side effect of the behavior introduced for ignoring the deselection of certain types of `selectedFeatures`. This newly introduced logic will set the state rapidly twice -- once to deselect the feature if necessary, and again to set the proper state of the application in response to the user action. This logic must be consolidated into a single call of `setState` so that there are no intermediate states of the application where certain components cannot render properly. It seems like best practice to set the state as infrequently as possible, anyways. 

To do this, I abstracted out the deselection method into a check that can be incorporated into building the state object that is set in the appropriate methods - thus allowing the `setState` to be called once. This fixes the scroll issue, and as an added-bonus, causes less `componentDidUpdate` calls across the board. 