### PR TITLE
Fix Slow Jobs List Rendering

### DIFF
--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -73,6 +73,10 @@ export class JobStatus extends React.Component<Props, State> {
     this.toggleExpansion        = this.toggleExpansion.bind(this)
   }
 
+  shouldComponentUpdate(nextProps) {
+    return ((this.props.isActive !== nextProps.isActive) || (this.props.className !== nextProps.className))
+  }
+
   render() {
     const { id, properties } = this.props.job
     const hasError = properties.errorDetails ? true : false

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -297,7 +297,6 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateInteractions()
     }
 
-
   }
 
   render() {


### PR DESCRIPTION
After profiling, I discovered the `JobStatus.tsx` components were rendering WAYY too often. 

It was probably rendering so much because previous commits injected the `selectedFeature` prop - which changes all the time. So every time the feature changed, every single `JobStatus.tsx` component was re-rendering. 

With the appropriate `shouldComponentUpdate`, everything looks great. 

This is dependent on the BEAC-47 branch being merged. 