### PR TITLE
Fix Frame Style Updates

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -292,11 +292,16 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateView()
     }
 
+    if ((previousProps.view.zoom !== this.props.view.zoom) ||
+      (previousProps.selectedFeature !== this.props.selectedFeature) ||
+      (previousProps.frames !== this.props.frames)) {
+      this.updateStyles();
+    }
+
     if ((previousProps.mode !== this.props.mode) ||
       (previousState.isMeasuring !== this.state.isMeasuring)) {
       this.updateInteractions()
     }
-
   }
 
   render() {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -234,7 +234,6 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (previousProps.selectedFeature !== this.props.selectedFeature) {
       this.renderSelectionPreview()
       this.updateSelectedFeature()
-      this.updateStyles()
     }
 
     if (previousProps.detections !== this.props.detections) {
@@ -264,7 +263,6 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (previousProps.frames !== this.props.frames) {
       this.renderFrames()
       this.renderPins()
-      this.updateStyles()
     }
 
     if (previousProps.imagery !== this.props.imagery || routeChanged) {
@@ -292,7 +290,8 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateView()
     }
 
-    if ((previousProps.view.zoom !== this.props.view.zoom) ||
+    if ((!previousProps.view) || 
+      (previousProps.view.zoom !== this.props.view.zoom && this.props.view) ||
       (previousProps.selectedFeature !== this.props.selectedFeature) ||
       (previousProps.frames !== this.props.frames)) {
       this.updateStyles();


### PR DESCRIPTION
The styles for the frames and divots sometime do not update.

To reproduce:

1) Load the map and zoom all the way in, without making a jobs selection.

2) The opaque background for the frames does not disapear

3) Now select a feature. The frames now properly update and styles are correct.

4) Zoom out. The style is not updated and all labels improperly appear.

The “componentDidUpdate” needs proper eventing hooks to update the styles.

![image](https://user-images.githubusercontent.com/3855282/45427324-90640f80-b66c-11e8-865e-c4c937967be5.png)

This was introduced when I refactored some of the `updateStyles` logic. 