### PR TITLE
Remove Stem and Inner Divot from Selection

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -340,9 +340,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       : feature_or_id
 
     switch (feature ? feature.get(KEY_TYPE) : null) {
-      case TYPE_DIVOT_INBOARD:
       case TYPE_DIVOT_OUTBOARD:
-      case TYPE_STEM:
         // Proxy clicks on "inner" decorations out to the job frame itself
         this.featureId = feature.ol_uid
         const jobId = feature.get(KEY_OWNER_ID)


### PR DESCRIPTION
Clicking on the stem of a Job (the line connecting the green/red square to the image frame itself) or the inner divot (the black dot that the stem spawns from) will trigger a separate selection event. This means that if a user specifically clicks on the stem or inner divot of a job, that job will essentially be cycled through twice when a user clicks repeatedly on a point on the map to cycle through jobs.

![image](https://user-images.githubusercontent.com/3855282/45445705-f5cdf580-b698-11e8-8ae3-0f7161edeee9.png)

To reproduce this behavior, find two jobs that roughly overlap each others center points, as in the above screenshot. Click on the inner divot (the black square) of the first Job, and then repeatedly click on that point in space. You will get 2-3 selections (depending if you click on the divot+steam, or just the divot) for that Job before it cycles your selection to the next Job.
