### PR TITLE
Fix Stem/Inboard Divot Selection Behavior

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -783,7 +783,7 @@ export class PrimaryMap extends React.Component<Props, State> {
             return new Style({
               stroke: new Stroke({
                 color: 'black',
-                width: 10,
+                width: 1,
               }),
             })
           case TYPE_LABEL_MAJOR:

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -340,7 +340,9 @@ export class PrimaryMap extends React.Component<Props, State> {
       : feature_or_id
 
     switch (feature ? feature.get(KEY_TYPE) : null) {
+      case TYPE_DIVOT_INBOARD:
       case TYPE_DIVOT_OUTBOARD:
+      case TYPE_STEM:
         // Proxy clicks on "inner" decorations out to the job frame itself
         this.featureId = feature.ol_uid
         const jobId = feature.get(KEY_OWNER_ID)

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -340,9 +340,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       : feature_or_id
 
     switch (feature ? feature.get(KEY_TYPE) : null) {
-      case TYPE_DIVOT_INBOARD:
       case TYPE_DIVOT_OUTBOARD:
-      case TYPE_STEM:
         // Proxy clicks on "inner" decorations out to the job frame itself
         this.featureId = feature.ol_uid
         const jobId = feature.get(KEY_OWNER_ID)

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -290,11 +290,11 @@ export class PrimaryMap extends React.Component<Props, State> {
       this.updateView()
     }
 
-    if ((!previousProps.view) || 
+    if ((!previousProps.view) ||
       (previousProps.view.zoom !== this.props.view.zoom && this.props.view) ||
       (previousProps.selectedFeature !== this.props.selectedFeature) ||
       (previousProps.frames !== this.props.frames)) {
-      this.updateStyles();
+      this.updateStyles()
     }
 
     if ((previousProps.mode !== this.props.mode) ||
@@ -340,9 +340,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       : feature_or_id
 
     switch (feature ? feature.get(KEY_TYPE) : null) {
-      case TYPE_DIVOT_INBOARD:
       case TYPE_DIVOT_OUTBOARD:
-      case TYPE_STEM:
         // Proxy clicks on "inner" decorations out to the job frame itself
         this.featureId = feature.ol_uid
         const jobId = feature.get(KEY_OWNER_ID)
@@ -512,13 +510,14 @@ export class PrimaryMap extends React.Component<Props, State> {
 
   private handleSelect(event) {
     if (event.selected.length || event.deselected.length) {
-      let index = event.selected.findIndex(f => f.ol_uid === this.featureId) + 1
+      let validSelections = event.selected.filter(f => !ignoreFeatureInSelection(f))
+      let index = validSelections.findIndex(f => f.ol_uid === this.featureId) + 1
 
       if (!event.mapBrowserEvent.pointerEvent.shiftKey) {
-        index += event.selected.length - (index ? 2 : 1)
+        index += validSelections.length - (index ? 2 : 1)
       }
 
-      this.handleSelectFeature(event.selected[index % event.selected.length])
+      this.handleSelectFeature(validSelections[index % validSelections.length])
     }
   }
 
@@ -1322,6 +1321,17 @@ function getColorForStatus(status) {
     case STATUS_ERROR: return 'hsl(349, 100%, 60%)'
     case STATUS_CANCELLED: return 'hsl(0, 0%, 70%)'
     default: return 'magenta'
+  }
+}
+
+function ignoreFeatureInSelection(feature) {
+  switch (feature.get(KEY_TYPE)) {
+    // Ignore the selection events for inboard divots and stems
+    case TYPE_DIVOT_INBOARD:
+    case TYPE_STEM:
+      return true
+    default:
+      return false
   }
 }
 

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -510,14 +510,13 @@ export class PrimaryMap extends React.Component<Props, State> {
 
   private handleSelect(event) {
     if (event.selected.length || event.deselected.length) {
-      let validSelections = event.selected.filter(f => !ignoreFeatureInSelection(f))
-      let index = validSelections.findIndex(f => f.ol_uid === this.featureId) + 1
+      let index = event.selected.findIndex(f => f.ol_uid === this.featureId) + 1
 
       if (!event.mapBrowserEvent.pointerEvent.shiftKey) {
-        index += validSelections.length - (index ? 2 : 1)
+        index += event.selected.length - (index ? 2 : 1)
       }
 
-      this.handleSelectFeature(validSelections[index % validSelections.length])
+      this.handleSelectFeature(event.selected[index % event.selected.length])
     }
   }
 
@@ -784,7 +783,7 @@ export class PrimaryMap extends React.Component<Props, State> {
             return new Style({
               stroke: new Stroke({
                 color: 'black',
-                width: 1,
+                width: 10,
               }),
             })
           case TYPE_LABEL_MAJOR:
@@ -1304,6 +1303,9 @@ function generateSelectInteraction(...layers) {
       }
     },
     toggleCondition: condition.never,
+    filter: (feature: Feature) => {
+      return isFeatureTypeSelectable(feature)
+    },
   })
 }
 
@@ -1324,14 +1326,14 @@ function getColorForStatus(status) {
   }
 }
 
-function ignoreFeatureInSelection(feature) {
+function isFeatureTypeSelectable(feature) {
   switch (feature.get(KEY_TYPE)) {
     // Ignore the selection events for inboard divots and stems
     case TYPE_DIVOT_INBOARD:
     case TYPE_STEM:
-      return true
-    default:
       return false
+    default:
+      return true
   }
 }
 


### PR DESCRIPTION
Clicking on the stem of a Job (the line connecting the green/red square to the image frame itself) or the inner divot (the black dot that the stem spawns from) will trigger a separate selection event. This means that if a user specifically clicks on the stem or inner divot of a job, that job will essentially be cycled through twice when a user clicks repeatedly on a point on the map to cycle through jobs.

![image](https://user-images.githubusercontent.com/3855282/45492454-5bbe8980-b73a-11e8-82d7-172a603670d5.png)

To reproduce this error behavior, find two jobs that roughly overlap each others center points, as in the above screenshot. Click on the inner divot (the black square) of the first Job, and then repeatedly click on that point in space. You will get 2-3 selections (depending if you click on the divot+stem, or just the divot) for that Job before it cycles your selection to the next Job.

This PR fixes the issue. In the above scenario, you should only get a selection for each frame *once* no matter where you click. 