### PR TITLE
Prevent feature details overlay from intercepting pointer events.

### DIFF
--- a/src/components/FeatureDetails.css
+++ b/src/components/FeatureDetails.css
@@ -16,6 +16,7 @@
 
 .root {
   position: absolute;
+  pointer-events: none;
 }
 
 .sceneDetails {


### PR DESCRIPTION
The overlay was absorbing mouse events, making it impossible to pan or zoom the map when hovering over it. There was no need for interaction or text selection in the overlay, so I just disabled all pointer events for it.

![selection_053](https://user-images.githubusercontent.com/3220897/45665012-b9006500-bac3-11e8-8048-66668c38d10b.png)
