### PR TITLE
Fix Job Status Label Update Behavior

### DIFF
--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -78,6 +78,7 @@ export class JobStatus extends React.Component<Props, State> {
   shouldComponentUpdate(nextProps, nextState) {
     return ((this.props.isActive !== nextProps.isActive) ||
       (this.props.className !== nextProps.className) ||
+      (this.props.job.properties.status !== nextProps.job.properties.status) ||
       (this.state.isExpanded !== nextState.isExpanded) ||
       (this.state.isDownloading !== nextState.isDownloading) ||
       (this.state.isControlHover !== nextState.isControlHover))


### PR DESCRIPTION
The job status label doesn't automatically refresh in the jobs list without user interaction. This is because the `shouldComponentUpdate` never took into account the status of the Job when determining if the component should re-render or not. This fix includes that check. 