### PR TITLE
Standardize Error Placeholder Tile

### DIFF
--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -17,7 +17,6 @@
 require('ol/ol.css')
 const styles: any = require('./PrimaryMap.css')
 const tileErrorPlaceholder: string = require('../images/tile-error.png')
-const missingKeyPlaceholder: string = require('../images/tile-missing-key.png')
 
 import * as React from 'react'
 import {findDOMNode} from 'react-dom'
@@ -1380,20 +1379,10 @@ function toPreviewable(features: Array<beachfront.Job|beachfront.Scene>) {
   }))
 }
 
-function getPlaceholder() {
-  let placeholder = ''
-  if (localStorage.getItem('catalog_apiKey')) {
-    placeholder = tileErrorPlaceholder
-  } else {
-    placeholder = missingKeyPlaceholder
-  }
-  return placeholder
-}
-
 function tileLoadFunction(imageTile, src) {
   if (imageTile.loadingError) {
     delete imageTile.loadingError
-    imageTile.getImage().src = getPlaceholder()
+    imageTile.getImage().src = tileErrorPlaceholder
   } else {
     imageTile.getImage().src = src
   }
@@ -1402,7 +1391,7 @@ function tileLoadFunction(imageTile, src) {
 function detectionTileLoadFunction(imageTile, src) {
   if (imageTile.loadingError) {
     delete imageTile.loadingError
-    imageTile.getImage().src = getPlaceholder()
+    imageTile.getImage().src = tileErrorPlaceholder
   } else {
     const client = new XMLHttpRequest()
     client.open('GET', src)


### PR DESCRIPTION
In the UI, we used to show a “Missing API Key” background error image for the imagery when the user didn’t enter an API Key.

This was a good way to visually alert them that their API Key was missing (since a brand-new user will need to first enter it before seeing imagery).

However, now that we have Local landsat, and potentially other new data sources that dont rely on the single Planet key, this no longer makes sense.

This PR removes the "Missing API Key" placeholder with the generic one. 