### PR TITLE
Map looping.

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -56,6 +56,7 @@ import {
   SESSION_IDLE_UNITS,
 } from '../config'
 import {UserTour} from './Tour'
+import {wrap} from '../utils/math'
 
 import {
   TYPE_JOB,
@@ -866,12 +867,27 @@ function deserialize(): State {
 }
 
 function serialize(state: State) {
+  /*
+    Wrap map center to keep it within the -180/180 range. Otherwise the map may scroll awkardly on initial load to get
+    back to a far away location. Do the same for the bbox so that it's in the same starting location as the map.
+   */
+  const mapView = {...state.mapView}
+  mapView.center[0] = wrap(mapView.center[0], -180, 180)
+
+  let bbox = null
+  if (state.bbox) {
+    bbox = [...state.bbox]
+    const bboxWidth = bbox[2] - bbox[0]
+    bbox[0] = wrap(bbox[0], -180, 180)
+    bbox[2] = bbox[0] + bboxWidth
+  }
+
   sessionStorage.setItem('enabled_platforms_records', JSON.stringify(state.enabledPlatforms.records))
   sessionStorage.setItem('algorithms_records', JSON.stringify(state.algorithms.records))
-  sessionStorage.setItem('bbox', JSON.stringify(state.bbox))
+  sessionStorage.setItem('bbox', JSON.stringify(bbox))
   sessionStorage.setItem('geoserver', JSON.stringify(state.geoserver))
   sessionStorage.setItem('isSessionExpired', JSON.stringify(state.isSessionExpired))
-  sessionStorage.setItem('mapView', JSON.stringify(state.mapView))
+  sessionStorage.setItem('mapView', JSON.stringify(mapView))
   sessionStorage.setItem('searchCriteria', JSON.stringify(state.searchCriteria))
   sessionStorage.setItem('searchResults', JSON.stringify(state.searchResults))
   localStorage.setItem('catalog_apiKey', state.catalogApiKey)  // HACK

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -36,6 +36,7 @@ import {
   MODE_SELECT_IMAGERY,
   MODE_PRODUCT_LINES,
 } from './PrimaryMap'
+import Map from 'ol/map'
 import {ProductLineList} from './ProductLineList'
 import {SessionExpired} from './SessionExpired'
 import {SessionLoggedOut} from './SessionLoggedOut'
@@ -47,7 +48,10 @@ import * as productLinesService from '../api/productLines'
 import * as sessionService from '../api/session'
 import * as statusService from '../api/status'
 import {createCollection, Collection} from '../utils/collections'
-import {featureToExtent, getFeatureCenter} from '../utils/geometries'
+import {
+  featureToExtentWrapped,
+  getFeatureCenter,
+} from '../utils/geometries'
 import {
   RECORD_POLLING_INTERVAL,
   SESSION_IDLE_INTERVAL,
@@ -86,6 +90,7 @@ interface State {
   productLines?: Collection<beachfront.ProductLine>
 
   // Map state
+  map?: Map
   mapMode?: string
   detections?: (beachfront.Job | beachfront.ProductLine)[]
   frames?: (beachfront.Job | beachfront.ProductLine)[]
@@ -118,6 +123,7 @@ export class Application extends React.Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = props.deserialize()
+    this.handleMapInitialization = this.handleMapInitialization.bind(this)
     this.handleBoundingBoxChange = this.handleBoundingBoxChange.bind(this)
     this.handleCatalogApiKeyChange = this.handleCatalogApiKeyChange.bind(this)
     this.handleClearBbox = this.handleClearBbox.bind(this)
@@ -238,7 +244,7 @@ export class Application extends React.Component<Props, State> {
           view={this.state.mapView}
           wmsUrl={this.state.geoserver.wmsUrl}
           onBoundingBoxChange={this.handleBoundingBoxChange}
-          onMapInitialization={(collections: any) => this.setState({ collections })}
+          onMapInitialization={this.handleMapInitialization}
           onSearchPageChange={this.handleSearchSubmit}
           onSelectFeature={this.handleSelectFeature}
           onViewChange={mapView => this.setState({ mapView })}
@@ -506,6 +512,13 @@ export class Application extends React.Component<Props, State> {
       .catch(err => this.setState({ errors: [...this.state.errors, err] }))
   }
 
+  private handleMapInitialization(map: Map, collections: any) {
+    this.setState({
+      map,
+      collections,
+    })
+  }
+
   private handleBoundingBoxChange(bbox) {
     this.setState({
       bbox,
@@ -576,7 +589,7 @@ export class Application extends React.Component<Props, State> {
   private handleNavigateToJob(loc) {
     this.navigateTo(loc)
     const feature = this.state.jobs.records.find(j => loc.search.includes(j.id))
-    this.panToExtent(featureToExtent(feature))
+    this.panToExtent(featureToExtentWrapped(this.state.map, feature))
   }
 
   private handlePanToProductLine(productLine) {

--- a/src/components/StaticMinimap.tsx
+++ b/src/components/StaticMinimap.tsx
@@ -73,6 +73,7 @@ export class StaticMinimap extends React.Component<Props, {}> {
         }),
         new VectorLayer({
           source: new VectorSource({
+            wrapX: false,
             features: [
               new Feature({
                 geometry: bboxGeometry,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,3 +32,7 @@ export const SOURCE_DEFAULT = 'rapideye'
 export const TYPE_JOB = 'JOB'
 export const TYPE_PRODUCT_LINE = 'PRODUCT_LINE'
 export const TYPE_SCENE = 'SCENE'
+
+// Map Projections
+export const WGS84 = 'EPSG:4326'
+export const WEB_MERCATOR = 'EPSG:3857'

--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -17,9 +17,10 @@
 import proj from 'ol/proj'
 import GeoJSON from 'ol/format/geojson'
 import extent from 'ol/extent'
-
-const WGS84 = 'EPSG:4326'
-const WEB_MERCATOR = 'EPSG:3857'
+import Geometry from 'ol/geom/geometry'
+import MultiPolygon from 'ol/geom/multipolygon'
+import Map from 'ol/map'
+import {WEB_MERCATOR, WGS84} from '../constants'
 
 export function getFeatureCenter(feature, featureProjection = WGS84) {
   return extent.getCenter(featureToExtent(feature, featureProjection))
@@ -37,9 +38,19 @@ export function bboxToExtent(bbox: number[], featureProjection = WEB_MERCATOR, d
   }, {featureProjection, dataProjection}).getExtent()
 }
 
-export function featureToExtent(feature, featureProjection = WEB_MERCATOR, dataProjection = WGS84) {
+export function featureToExtent(feature: GeoJSON.Feature<GeoJSON.Polygon>,
+                                featureProjection = WEB_MERCATOR,
+                                dataProjection = WGS84) {
   const geometry = readFeatureGeometry(feature, featureProjection, dataProjection)
   return geometry.getExtent()
+}
+
+export function featureToExtentWrapped(map: Map,
+                                       feature: GeoJSON.Feature<GeoJSON.Polygon>,
+                                       featureProjection = WEB_MERCATOR,
+                                       dataProjection = WGS84) {
+  const geometry = readFeatureGeometry(feature, featureProjection, dataProjection)
+  return extentWrapped(map, calculateExtent(geometry))
 }
 
 export function readFeatureGeometry(feature, featureProjection = WEB_MERCATOR, dataProjection = WGS84) {
@@ -66,6 +77,59 @@ export function toGeoJSON(feature) {
     dataProjection: WGS84,
     featureProjection: WEB_MERCATOR,
   })
+}
+
+export function getWrapIndex(map: Map, positionWgs: [number, number]) {
+  // Return an index that signifies how many full map distances the position is from the map center.
+  const mapCenter = proj.transform(map.getView().getCenter(), WEB_MERCATOR, WGS84)
+  const distanceToMapCenter = mapCenter[0] - positionWgs[0]
+
+  if (distanceToMapCenter < 0) {
+    return Math.ceil((distanceToMapCenter - 180) / 360)
+  } else {
+    return Math.floor((distanceToMapCenter + 180) / 360)
+  }
+}
+
+export function extentWrapped(map: Map, extent: [number, number, number, number]) {
+  // Return an extent that's wrapped so that it follows the camera as it pans across a looping map.
+  let extentWgs = proj.transformExtent(extent, WEB_MERCATOR, WGS84)
+  const centroid = [
+    (extentWgs[0] + extentWgs[2]) / 2,
+    (extentWgs[1] + extentWgs[3]) / 2,
+  ] as [number, number]
+
+  const wrapIndex = getWrapIndex(map, centroid)
+  extentWgs[0] += wrapIndex * 360
+  extentWgs[2] += wrapIndex * 360
+
+  return proj.transformExtent(extentWgs, WGS84, WEB_MERCATOR)
+}
+
+export function calculateExtent(geometry: Geometry) {
+  if (geometry instanceof MultiPolygon && crossesMeridian(geometry)) {
+    const extents = geometry.getPolygons().map(g => proj.transformExtent(g.getExtent(), WEB_MERCATOR, WGS84))
+    let [, minY, , maxY] = proj.transformExtent(geometry.getExtent(), WEB_MERCATOR, WGS84)
+    let width = 0
+    let minX = 180
+
+    for (const [polygonMinX, , polygonMaxX] of extents) {
+      width += polygonMaxX - polygonMinX
+
+      if (polygonMaxX > 0) {
+        minX -= polygonMaxX - polygonMinX
+      }
+    }
+
+    return proj.transformExtent([minX, minY, minX + width, maxY], WGS84, WEB_MERCATOR)
+  }
+
+  return geometry.getExtent()  // Use as-is
+}
+
+export function crossesMeridian(geometry: Geometry) {
+  const [minX, , maxX] = proj.transformExtent(geometry.getExtent(), WEB_MERCATOR, WGS84)
+  return minX === -180 && maxX === 180
 }
 
 //

--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -56,9 +56,9 @@ export function deserializeBbox(serialized) {
 
 export function serializeBbox(extent) {
   const bbox = proj.transformExtent(extent, WEB_MERCATOR, WGS84)
-  const p1 = unwrapPoint(bbox.slice(0, 2))
-  const p2 = unwrapPoint(bbox.slice(2, 4))
-  return p1.concat(p2).map(truncate)
+  const p1 = bbox.slice(0, 2)
+  const p2 = bbox.slice(2, 4)
+  return p1.concat(p2).map(truncate) as [number, number, number, number]
 }
 
 export function toGeoJSON(feature) {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016, RadiantBlue Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+export function mod(n: number, m: number) {
+  // Perform a proper modulo operation (in JavaScript % actually performs a remainder operation).
+  return ((n % m) + m) % m
+}
+
+export function wrap(n: number, min: number, max: number) {
+  // Wrap n between min and max (inclusive for min and exclusive for max).
+  const range = max - min
+  return min + mod(n - min, range)
+}

--- a/src/utils/openlayers.MeasureControl.ts
+++ b/src/utils/openlayers.MeasureControl.ts
@@ -197,9 +197,7 @@ function generateInteraction(drawLayer) {
 
 function generateLayer() {
   return new VectorLayer({
-    source: new VectorSource({
-      wrapX: false,
-    }),
+    source: new VectorSource(),
     style: new Style({
       stroke: new Stroke({
         color: '#c03',


### PR DESCRIPTION
All elements should now loop infinitely in the X axis on the map.

I tried to keep the solution for this as simple as possible, but there's still a lot of potential for bugs due to the complexity. So you may want to test as many edge cases as you can think of. I've tested as many cases as I could think of, but it's very possible I've missed some.

It's also important to test page refreshes, since I had to transform the bbox and map center back to the initial -180/180 range in the serialization code to prevent the map from potentially panning extremely far on the initial load.