### PR TITLE
Proper Removal Update Hook

### DIFF
--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -81,7 +81,8 @@ export class JobStatus extends React.Component<Props, State> {
       (this.props.job.properties.status !== nextProps.job.properties.status) ||
       (this.state.isExpanded !== nextState.isExpanded) ||
       (this.state.isDownloading !== nextState.isDownloading) ||
-      (this.state.isControlHover !== nextState.isControlHover))
+      (this.state.isControlHover !== nextState.isControlHover) ||
+      (this.state.isRemoving !== nextState.isRemoving))
   }
 
   render() {


### PR DESCRIPTION
When attempting to 'Remove Job' from the jobs menu, nothing happens upon clicking the 'Remove Job' text. Instead, user has to click away from that button/link in order to advance the 'Remove Job' workflow to the next step which is the dialog asking if you want to remove the job and then execution.

This PR fixes the issue. The issue was because the `shouldComponentUpdate` had no check to see if the Job was removing (as in - the yellow removal confirmation was being displayed)