### PR TITLE
Scroll to Job Fix

### DIFF
--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -91,7 +91,7 @@ export class JobStatus extends React.Component<Props, State> {
     const timeOfCollect = moment.utc(properties.time_of_collect).local().format('llll')
 
     return (
-      <li className={`${styles.root} ${this.aggregatedClassNames}`}>
+      <li className={`${styles.root} ${this.aggregatedClassNames} ${this.activeJobId}`}>
         <div
           className={styles.progressBar}
           title={`${isNaN(this.state.downloadProgress) ? '—' : this.state.downloadProgress}%`}
@@ -181,6 +181,10 @@ export class JobStatus extends React.Component<Props, State> {
   //
   // Internals
   //
+
+  private get activeJobId() {
+    return 'JobStatus-' + this.props.job.properties.job_id
+  }
 
   private get aggregatedClassNames() {
     return [

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -79,7 +79,8 @@ export class JobStatusList extends React.Component<Props, void> {
   }
 
   private scrollToSelectedJob() {
-    const row = document.querySelector(`.${jobStatusStyles.isActive}`)
+    const job = this.props.selectedFeature as beachfront.Job
+    const row = document.querySelector(`.JobStatus-${job.properties.job_id}`)
     if (row) {
       const offset = [
         '.JobStatusList-root header',

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -80,18 +80,20 @@ export class JobStatusList extends React.Component<Props, void> {
 
   private scrollToSelectedJob() {
     const job = this.props.selectedFeature as beachfront.Job
-    const row = document.querySelector(`.JobStatus-${job.properties.job_id}`)
-    if (row) {
-      const offset = [
-        '.JobStatusList-root header',
-        '.ClassificationBanner-root',
-      ].reduce((rc, s) => rc + document.querySelector(s).clientHeight, 0)
+    if (job) {
+      const row = document.querySelector(`.JobStatus-${job.properties.job_id}`)
+      if (row) {
+        const offset = [
+          '.JobStatusList-root header',
+          '.ClassificationBanner-root',
+        ].reduce((rc, s) => rc + document.querySelector(s).clientHeight, 0)
 
-      const box = row.getBoundingClientRect()
-      const height = window.innerHeight || document.documentElement.clientHeight
+        const box = row.getBoundingClientRect()
+        const height = window.innerHeight || document.documentElement.clientHeight
 
-      if (Math.floor(box.top) <= offset || box.bottom > height - row.clientHeight) {
-        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        if (Math.floor(box.top) <= offset || box.bottom > height - row.clientHeight) {
+          row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        }
       }
     }
   }


### PR DESCRIPTION
This PR fixes the bug where selecting a Job on the map no longer scrolls appropriately to that Job in the list.

To test:

* Bring up the Jobs List
* Click on a Job on the map
* Ensure that the Job is properly scrolled to in the Jobs list