### PR TITLE
Refactor OpenLayers imports.

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -36,7 +36,6 @@ import {
   MODE_SELECT_IMAGERY,
   MODE_PRODUCT_LINES,
 } from './PrimaryMap'
-import Map from 'ol/map'
 import {ProductLineList} from './ProductLineList'
 import {SessionExpired} from './SessionExpired'
 import {SessionLoggedOut} from './SessionLoggedOut'
@@ -47,6 +46,7 @@ import * as jobsService from '../api/jobs'
 import * as productLinesService from '../api/productLines'
 import * as sessionService from '../api/session'
 import * as statusService from '../api/status'
+import * as ol from '../utils/ol'
 import {createCollection, Collection} from '../utils/collections'
 import {
   featureToExtentWrapped,
@@ -90,7 +90,7 @@ interface State {
   productLines?: Collection<beachfront.ProductLine>
 
   // Map state
-  map?: Map
+  map?: ol.Map
   mapMode?: string
   detections?: (beachfront.Job | beachfront.ProductLine)[]
   frames?: (beachfront.Job | beachfront.ProductLine)[]
@@ -512,7 +512,7 @@ export class Application extends React.Component<Props, State> {
       .catch(err => this.setState({ errors: [...this.state.errors, err] }))
   }
 
-  private handleMapInitialization(map: Map, collections: any) {
+  private handleMapInitialization(map: ol.Map, collections: any) {
     this.setState({
       map,
       collections,
@@ -711,7 +711,7 @@ export class Application extends React.Component<Props, State> {
     })
   }
 
-  private panToExtent(extent: ol.Extent) {
+  private panToExtent(extent: [number, number, number, number]) {
     this.setState({
       mapView: {
         ...this.state.mapView,

--- a/src/components/ImagerySearchList.tsx
+++ b/src/components/ImagerySearchList.tsx
@@ -20,8 +20,7 @@ const DATETIME_FORMAT = 'YYYY-MM-DD HH:mm'
 import * as React from 'react'
 import * as moment from 'moment'
 import * as debounce from 'lodash/debounce'
-import Collection from 'ol/collection'
-import Select from 'ol/interaction/select'
+import * as ol from '../utils/ol'
 import {SCENE_TILE_PROVIDERS} from '../config'
 
 interface Props {
@@ -171,7 +170,7 @@ export class ImagerySearchList extends React.Component<Props, State> {
     return provider ? provider.name : null
   }
 
-  private getFeatureIds(collection: Collection): string[] {
+  private getFeatureIds(collection: ol.Collection): string[] {
     return collection.getArray().map(f => f.getId())
   }
 
@@ -199,13 +198,13 @@ export class ImagerySearchList extends React.Component<Props, State> {
     }
   }
 
-  private setHoveredIds(event?: Select.Event): void {
+  private setHoveredIds(event?: ol.Select.Event): void {
     this.setState((_, props) => ({
       hoveredIds: this.getFeatureIds(event ? event.target : props.collections.hovered),
     }))
   }
 
-  private setSelectedIds(event?: Select.Event): void {
+  private setSelectedIds(event?: ol.Select.Event): void {
     this.setState((_, props) => ({
       selectedIds: this.getFeatureIds(event ? event.target : props.collections.selected),
     }), this.scrollToSelected)

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -20,42 +20,9 @@ const tileErrorPlaceholder: string = require('../images/tile-error.png')
 
 import * as React from 'react'
 import {findDOMNode} from 'react-dom'
-import Collection from 'ol/collection'
-import LineString from 'ol/geom/linestring'
-import Draw from 'ol/interaction/draw'
-import VectorLayer from 'ol/layer/vector'
-import proj from 'ol/proj'
-import VectorSource from 'ol/source/vector'
-import RegularShape from 'ol/style/regularshape'
-import Stroke from 'ol/style/stroke'
-import Style from 'ol/style/style'
-import control from 'ol/control'
-import FullScreen from 'ol/control/fullscreen'
-import MousePosition from 'ol/control/mouseposition'
-import ScaleLine from 'ol/control/scaleline'
-import ZoomSlider from 'ol/control/zoomslider'
-import coordinate from 'ol/coordinate'
-import condition from 'ol/events/condition'
-import extent from 'ol/extent'
-import Feature from 'ol/feature'
-import GeoJSON from 'ol/format/geojson'
-import Point from 'ol/geom/point'
-import Polygon from 'ol/geom/polygon'
-import interaction from 'ol/interaction'
-import DragRotate from 'ol/interaction/dragrotate'
-import Select from 'ol/interaction/select'
-import Tile from 'ol/layer/tile'
-import Map from 'ol/map'
-import Overlay from 'ol/overlay'
-import TileWMS from 'ol/source/tilewms'
-import XYZ from 'ol/source/xyz'
-import Fill from 'ol/style/fill'
-import Text from 'ol/style/text'
-import View from 'ol/view'
-import Image from 'ol/layer/image'
-import ImageStatic from 'ol/source/imagestatic'
 import * as debounce from 'lodash/debounce'
 import * as throttle from 'lodash/throttle'
+import * as ol from '../utils/ol'
 import {ExportControl} from '../utils/openlayers.ExportControl'
 import {SearchControl} from '../utils/openlayers.SearchControl'
 import {MeasureControl} from '../utils/openlayers.MeasureControl'
@@ -135,7 +102,7 @@ interface Props {
   wmsUrl:             string
   shrunk:             boolean
   onBoundingBoxChange(bbox: number[])
-  onMapInitialization(map: Map, collections: any)
+  onMapInitialization(map: ol.Map, collections: any)
   onSearchPageChange(page: {count: number, startIndex: number})
   onSelectFeature(feature: beachfront.Job | beachfront.Scene)
   onViewChange(view: MapView)
@@ -155,28 +122,28 @@ export interface MapView {
   basemapIndex: number
   center?: [number, number]
   zoom?: number
-  extent?: ol.Extent
+  extent?: [number, number, number, number]
 }
 
 export class PrimaryMap extends React.Component<Props, State> {
   refs: any
 
-  private basemapLayers: Tile[]
-  private bboxDrawInteraction: Draw
-  private detectionsLayers: {[key: string]: Tile}
-  private drawLayer: VectorLayer
-  private featureDetailsOverlay: Overlay
+  private basemapLayers: ol.Tile[]
+  private bboxDrawInteraction: ol.Draw
+  private detectionsLayers: {[key: string]: ol.Tile}
+  private drawLayer: ol.VectorLayer
+  private featureDetailsOverlay: ol.Overlay
   private featureId?: number | string
-  private frameLayer: VectorLayer
-  private frameFillLayer: VectorLayer
-  private pinLayer: VectorLayer
-  private highlightLayer: VectorLayer
-  private hoverInteraction: Select
-  private imageSearchResultsOverlay: Overlay
-  private imageryLayer: VectorLayer
-  private map: Map
-  private previewLayers: {[key: string]: Tile}
-  private selectInteraction: Select
+  private frameLayer: ol.VectorLayer
+  private frameFillLayer: ol.VectorLayer
+  private pinLayer: ol.VectorLayer
+  private highlightLayer: ol.VectorLayer
+  private hoverInteraction: ol.Select
+  private imageSearchResultsOverlay: ol.Overlay
+  private imageryLayer: ol.VectorLayer
+  private map: ol.Map
+  private previewLayers: {[key: string]: ol.Tile}
+  private selectInteraction: ol.Select
   private skipNextViewUpdate: boolean
 
   constructor() {
@@ -444,7 +411,7 @@ export class PrimaryMap extends React.Component<Props, State> {
   private emitViewChange() {
     const view = this.map.getView()
     const {basemapIndex} = this.state
-    const center = proj.transform(view.getCenter(), WEB_MERCATOR, WGS84)
+    const center = ol.proj.transform(view.getCenter(), WEB_MERCATOR, WGS84)
     const zoom = view.getZoom() || MIN_ZOOM  // HACK -- sometimes getZoom returns undefined...
 
     // Don't emit false positives
@@ -465,13 +432,13 @@ export class PrimaryMap extends React.Component<Props, State> {
 
     // Check if we should re-render any manually looped elements.
     if (this.props.selectedFeature) {
-      let selectedFeatureCenter = extent.getCenter(featureToExtent(this.props.selectedFeature))
-      selectedFeatureCenter = proj.transform(selectedFeatureCenter, WEB_MERCATOR, WGS84)
+      let selectedFeatureCenter = ol.extent.getCenter(featureToExtent(this.props.selectedFeature))
+      selectedFeatureCenter = ol.proj.transform(selectedFeatureCenter, WEB_MERCATOR, WGS84)
       selectedFeatureHalfWrapIndex = getWrapIndex(this.map, selectedFeatureCenter)
     }
 
     if (this.props.bbox) {
-      let bboxCenter = extent.getCenter(this.props.bbox)
+      let bboxCenter = ol.extent.getCenter(this.props.bbox)
       bboxHalfWrapIndex = getWrapIndex(this.map, bboxCenter)
     }
 
@@ -594,7 +561,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.featureDetailsOverlay = generateFeatureDetailsOverlay(this.refs.featureDetails)
     this.imageSearchResultsOverlay = generateImageSearchResultsOverlay(this.refs.imageSearchResults)
 
-    this.map = new Map({
+    this.map = new ol.Map({
       controls: generateControls(),
       interactions: generateBaseInteractions().extend([
         this.bboxDrawInteraction,
@@ -612,8 +579,8 @@ export class PrimaryMap extends React.Component<Props, State> {
         this.highlightLayer,
       ],
       target: this.refs.container,
-      view: new View({
-        center: proj.fromLonLat(DEFAULT_CENTER, WEB_MERCATOR),
+      view: new ol.View({
+        center: ol.proj.fromLonLat(DEFAULT_CENTER, WEB_MERCATOR),
         minZoom: MIN_ZOOM,
         maxZoom: MAX_ZOOM,
         zoom: MIN_ZOOM,
@@ -661,7 +628,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       })
     } else {
       view.animate({
-        center: view.constrainCenter(proj.transform(center, WGS84, WEB_MERCATOR)),
+        center: view.constrainCenter(ol.proj.transform(center, WGS84, WEB_MERCATOR)),
         zoom,
         duration,
       })
@@ -686,10 +653,10 @@ export class PrimaryMap extends React.Component<Props, State> {
     // Render detections.
     const insertionIndex = this.map.getLayers().getArray().indexOf(this.frameLayer)
     this.props.detections.forEach(detection => {
-      let layer: Tile
+      let layer: ol.Tile
 
       let extent = featureToExtentWrapped(this.map, detection)
-      layer = new Tile({
+      layer = new ol.Tile({
         source: generateDetectionsSource(this.props.wmsUrl, detection),
         extent,
       })
@@ -705,7 +672,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.clearPins()
 
     const source = this.pinLayer.getSource()
-    const reader = new GeoJSON()
+    const reader = new ol.GeoJSON()
 
     this.props.frames.forEach(raw => {
       const frame = reader.readFeature(raw, {
@@ -714,12 +681,12 @@ export class PrimaryMap extends React.Component<Props, State> {
       })
 
       const frameExtent = calculateExtent(frame.getGeometry())
-      const topRight = extent.getTopRight(extent.buffer(frameExtent, STEM_OFFSET))
-      const center = extent.getCenter(frameExtent)
+      const topRight = ol.extent.getTopRight(ol.extent.buffer(frameExtent, STEM_OFFSET))
+      const center = ol.extent.getCenter(frameExtent)
       const id = frame.getId()
 
-      const stem = new Feature({
-        geometry: new LineString([
+      const stem = new ol.Feature({
+        geometry: new ol.LineString([
           center,
           topRight,
         ]),
@@ -729,24 +696,24 @@ export class PrimaryMap extends React.Component<Props, State> {
       stem.set(KEY_OWNER_ID, id)
       source.addFeature(stem)
 
-      const divotInboard = new Feature({ geometry: new Point(center) })
+      const divotInboard = new ol.Feature({ geometry: new ol.Point(center) })
       divotInboard.set(KEY_TYPE, TYPE_DIVOT_INBOARD)
       divotInboard.set(KEY_OWNER_ID, id)
       source.addFeature(divotInboard)
 
-      const divotOutboard = new Feature({ geometry: new Point(topRight) })
+      const divotOutboard = new ol.Feature({ geometry: new ol.Point(topRight) })
       divotOutboard.set(KEY_TYPE, TYPE_DIVOT_OUTBOARD)
       divotOutboard.set(KEY_OWNER_ID, id)
       divotOutboard.set(KEY_STATUS, raw.properties.status)
       source.addFeature(divotOutboard)
 
-      const name = new Feature({ geometry: new Point(topRight) })
+      const name = new ol.Feature({ geometry: new ol.Point(topRight) })
       name.set(KEY_TYPE, TYPE_LABEL_MAJOR)
       name.set(KEY_OWNER_ID, id)
       name.set(KEY_NAME, raw.properties.name.toUpperCase())
       source.addFeature(name)
 
-      const status = new Feature({ geometry: new Point(topRight) })
+      const status = new ol.Feature({ geometry: new ol.Point(topRight) })
       status.set(KEY_TYPE, TYPE_LABEL_MINOR)
       status.set(KEY_OWNER_ID, id)
       status.set(KEY_STATUS, raw.properties.status)
@@ -760,7 +727,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.clearFrames()
 
     const source = this.frameLayer.getSource()
-    const reader = new GeoJSON()
+    const reader = new ol.GeoJSON()
 
     this.props.frames.forEach(raw => {
       const frame = reader.readFeature(raw, {
@@ -776,7 +743,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     this.clearFrameFills()
 
     const source = this.frameFillLayer.getSource()
-    const reader = new GeoJSON()
+    const reader = new ol.GeoJSON()
 
     this.props.frames.forEach(raw => {
       const frame = reader.readFeature(raw, {
@@ -795,8 +762,8 @@ export class PrimaryMap extends React.Component<Props, State> {
     frames.forEach(feature => {
       const isSelected = (this.props.selectedFeature && this.props.selectedFeature.id === feature.getId())
 
-      feature.setStyle(new Style({
-        stroke: new Stroke({
+      feature.setStyle(new ol.Style({
+        stroke: new ol.Stroke({
           color: isSelected ? 'black' : 'transparent',
           width: 2,
         }),
@@ -807,13 +774,13 @@ export class PrimaryMap extends React.Component<Props, State> {
     framesFills.forEach(feature => {
       const isSelected = (this.props.selectedFeature && this.props.selectedFeature.id === feature.getId())
 
-      feature.setStyle(new Style({
-        stroke: new Stroke({
+      feature.setStyle(new ol.Style({
+        stroke: new ol.Stroke({
           color: isSelected ? 'transparent' : 'rgba(0, 0, 0, .4)',
           lineDash: isSelected ? undefined : [10, 10],
           width: 1,
         }),
-        fill: new Fill({
+        fill: new ol.Fill({
           color: (isClose || isSelected) ? 'transparent' : 'hsla(202, 100%, 85%, 0.5)',
         }),
       }))
@@ -825,43 +792,43 @@ export class PrimaryMap extends React.Component<Props, State> {
       feature.setStyle(() => {
         switch (feature.get(KEY_TYPE)) {
           case TYPE_DIVOT_INBOARD:
-            return new Style({
-              image: new RegularShape({
+            return new ol.Style({
+              image: new ol.RegularShape({
                 angle: Math.PI / 4,
                 points: 4,
                 radius: 5,
-                fill: new Fill({
+                fill: new ol.Fill({
                   color: 'black',
                 }),
               }),
             })
           case TYPE_DIVOT_OUTBOARD:
-            return new Style({
-              image: new RegularShape({
+            return new ol.Style({
+              image: new ol.RegularShape({
                 angle: Math.PI / 4,
                 points: 4,
                 radius: isSelected ? 15 : 10,
-                stroke: new Stroke({
+                stroke: new ol.Stroke({
                   color: 'black',
                   width: isSelected ? 2 : 1,
                 }),
-                fill: new Fill({
+                fill: new ol.Fill({
                   color: getColorForStatus(feature.get(KEY_STATUS)),
                 }),
               }),
               zIndex: isSelected ? 1 : undefined,
             })
           case TYPE_STEM:
-            return new Style({
-              stroke: new Stroke({
+            return new ol.Style({
+              stroke: new ol.Stroke({
                 color: 'black',
                 width: 1,
               }),
             })
           case TYPE_LABEL_MAJOR:
-            return new Style({
-              text: new Text({
-                fill: new Fill({
+            return new ol.Style({
+              text: new ol.Text({
+                fill: new ol.Fill({
                   color: isClose || isSelected ? 'black' : 'transparent',
                 }),
                 offsetX: 13,
@@ -876,9 +843,9 @@ export class PrimaryMap extends React.Component<Props, State> {
             const name = feature.get(KEY_NAME)
             const sceneId = normalizeSceneId(feature.get(KEY_SCENE_ID))
 
-            return new Style({
-              text: new Text({
-                fill: new Fill({
+            return new ol.Style({
+              text: new ol.Text({
+                fill: new ol.Fill({
                   color: isClose ? 'rgba(0,0,0,.6)' : 'transparent',
                 }),
                 offsetX: 13,
@@ -906,7 +873,7 @@ export class PrimaryMap extends React.Component<Props, State> {
       return
     }
 
-    const reader = new GeoJSON()
+    const reader = new ol.GeoJSON()
     const feature = reader.readFeature(geojson, {
       dataProjection: WGS84,
       featureProjection: WEB_MERCATOR,
@@ -917,7 +884,7 @@ export class PrimaryMap extends React.Component<Props, State> {
 
   private renderImagery() {
     const {imagery} = this.props
-    const reader = new GeoJSON()
+    const reader = new ol.GeoJSON()
     const source = this.imageryLayer.getSource()
 
     source.setAttributions(undefined)
@@ -958,12 +925,12 @@ export class PrimaryMap extends React.Component<Props, State> {
     let position
     if (this.props.imagery.count) {
       // Pager
-      position = extent.getBottomRight(bbox)
+      position = ol.extent.getBottomRight(bbox)
       this.imageSearchResultsOverlay.setPosition(position)
       this.imageSearchResultsOverlay.setPositioning('top-right')
     } else {
       // No results
-      position = extent.getCenter(bbox)
+      position = ol.extent.getCenter(bbox)
       this.imageSearchResultsOverlay.setPosition(position)
       this.imageSearchResultsOverlay.setPositioning('center-center')
     }
@@ -972,7 +939,7 @@ export class PrimaryMap extends React.Component<Props, State> {
     if (autoPan) {
       // Only auto-pan if the overlay is outside of the view.
       const viewExtent = this.map.getView().calculateExtent(this.map.getSize())
-      if (!extent.containsCoordinate(viewExtent, position)) {
+      if (!ol.extent.containsCoordinate(viewExtent, position)) {
         this.map.getView().animate({
           center: position,
           duration: 1000,
@@ -990,7 +957,7 @@ export class PrimaryMap extends React.Component<Props, State> {
 
     bbox = extentWrapped(this.map, bbox)
 
-    const feature = new Feature({ geometry: Polygon.fromExtent(bbox) })
+    const feature = new ol.Feature({ geometry: ol.Polygon.fromExtent(bbox) })
     this.drawLayer.getSource().addFeature(feature)
   }
 
@@ -1021,15 +988,15 @@ export class PrimaryMap extends React.Component<Props, State> {
       }
 
       const {catalogApiKey} = this.props
-      let layer: Tile
+      let layer: ol.Tile
 
       if (provider.isXYZProvider) {
-        layer = new Tile({
+        layer = new ol.Tile({
           source: generateXYZScenePreviewSource(provider, externalId, catalogApiKey),
           extent: f.extentWrapped,
         })
       } else {
-        layer = new Image({
+        layer = new ol.Image({
           source: generateImageStaticScenePreviewSource(provider, externalId, f.extentWrapped, catalogApiKey),
         })
       }
@@ -1107,12 +1074,12 @@ export class PrimaryMap extends React.Component<Props, State> {
       return  // Nothing to do
     }
 
-    const reader = new GeoJSON()
+    const reader = new ol.GeoJSON()
     const feature = reader.readFeature(selectedFeature, {
       dataProjection: WGS84,
       featureProjection: WEB_MERCATOR,
     })
-    const anchor = extent.getTopRight(featureToExtentWrapped(this.map, selectedFeature))
+    const anchor = ol.extent.getTopRight(featureToExtentWrapped(this.map, selectedFeature))
     features.push(feature)
     this.featureDetailsOverlay.setPosition(anchor)
   }
@@ -1139,11 +1106,11 @@ function animateLayerExit(layer) {
 
 function generateBasemapLayers(providers) {
   return providers.map((provider, index) => {
-    const source = new XYZ(Object.assign({}, provider, {
+    const source = new ol.XYZ(Object.assign({}, provider, {
       crossOrigin: 'anonymous',
       tileLoadFunction,
     }))
-    const layer = new Tile({source})
+    const layer = new ol.Tile({source})
 
     layer.setProperties({ name: provider.name, visible: index === 0 })
 
@@ -1152,29 +1119,29 @@ function generateBasemapLayers(providers) {
 }
 
 function generateBaseInteractions() {
-  return interaction.defaults().extend([
-    new DragRotate({
-      condition: condition.altKeyOnly,
+  return ol.interaction.defaults().extend([
+    new ol.DragRotate({
+      condition: ol.condition.altKeyOnly,
     }),
   ])
 }
 
 function generateControls() {
-  return control.defaults({
+  return ol.control.defaults({
     attributionOptions: {
       collapsible: false,
     },
   }).extend([
-    new ScaleLine({
+    new ol.ScaleLine({
       minWidth: 250,
       units: 'nautical',
     }),
-    new ZoomSlider(),
-    new MousePosition({
-      coordinateFormat: coordinate.toStringHDMS,
+    new ol.ZoomSlider(),
+    new ol.MousePosition({
+      coordinateFormat: ol.coordinate.toStringHDMS,
       projection: WGS84,
     }),
-    new FullScreen(),
+    new ol.FullScreen(),
     new ExportControl(styles.export),
     new SearchControl(styles.search),
     new MeasureControl(styles.measure),
@@ -1183,7 +1150,7 @@ function generateControls() {
 }
 
 function generateDetectionsSource(wmsUrl, feature: beachfront.Job|beachfront.ProductLine) {
-  return new TileWMS({
+  return new ol.TileWMS({
     tileLoadFunction: detectionTileLoadFunction,
     crossOrigin: 'anonymous',
     url: wmsUrl,
@@ -1196,15 +1163,15 @@ function generateDetectionsSource(wmsUrl, feature: beachfront.Job|beachfront.Pro
 }
 
 function generateDrawLayer() {
-  return new VectorLayer({
-    source: new VectorSource({
+  return new ol.VectorLayer({
+    source: new ol.VectorSource({
       wrapX: false,
     }),
-    style: new Style({
-      fill: new Fill({
+    style: new ol.Style({
+      fill: new ol.Fill({
         color: 'hsla(202, 70%, 50%, 0.35)',
       }),
-      stroke: new Stroke({
+      stroke: new ol.Stroke({
         color: 'hsla(202, 70%, 50%, 0.7)',
         width: 1,
         lineDash: [5, 5],
@@ -1214,21 +1181,21 @@ function generateDrawLayer() {
 }
 
 function generateBboxDrawInteraction(drawLayer) {
-  const draw = new Draw({
+  const draw = new ol.Draw({
     source: drawLayer.getSource(),
     maxPoints: 2,
     type: 'LineString',
-    geometryFunction(coordinates: any, geometry: Polygon) {
+    geometryFunction(coordinates: any, geometry: ol.Polygon) {
       if (!geometry) {
-        geometry = new Polygon(null)
+        geometry = new ol.Polygon(null)
       }
       const [[x1, y1], [x2, y2]] = coordinates
       geometry.setCoordinates([[[x1, y1], [x1, y2], [x2, y2], [x2, y1], [x1, y1]]])
       return geometry
     },
-    style: new Style({
-      image: new RegularShape({
-        stroke: new Stroke({
+    style: new ol.Style({
+      image: new ol.RegularShape({
+        stroke: new ol.Stroke({
           color: 'black',
           width: 1,
         }),
@@ -1237,10 +1204,10 @@ function generateBboxDrawInteraction(drawLayer) {
         radius2: 0,
         angle: 0,
       }),
-      fill: new Fill({
+      fill: new ol.Fill({
         color: 'hsla(202, 70%, 50%, .6)',
       }),
-      stroke: new Stroke({
+      stroke: new ol.Stroke({
         color: 'hsl(202, 70%, 50%)',
         width: 1,
         lineDash: [5, 5],
@@ -1254,7 +1221,7 @@ function generateBboxDrawInteraction(drawLayer) {
 }
 
 function generateFeatureDetailsOverlay(componentRef) {
-  return new Overlay({
+  return new ol.Overlay({
     element:     findDOMNode(componentRef),
     id:          'featureDetails',
     positioning: 'top-left',
@@ -1262,13 +1229,13 @@ function generateFeatureDetailsOverlay(componentRef) {
 }
 
 function generateHighlightLayer() {
-  return new VectorLayer({
-    source: new VectorSource(),
-    style: new Style({
-      fill: new Fill({
+  return new ol.VectorLayer({
+    source: new ol.VectorSource(),
+    style: new ol.Style({
+      fill: new ol.Fill({
         color: 'hsla(90, 100%, 30%, .5)',
       }),
-      stroke: new Stroke({
+      stroke: new ol.Stroke({
         color: 'hsla(90, 100%, 30%, .6)',
       }),
     }),
@@ -1276,12 +1243,12 @@ function generateHighlightLayer() {
 }
 
 function generateHoverInteraction(...layers) {
-  return new Select({
+  return new ol.Select({
     layers,
     multi: true,
-    condition: e => condition.pointerMove(e) && condition.noModifierKeys(e),
-    style: new Style({
-      stroke: new Stroke({
+    condition: e => ol.condition.pointerMove(e) && ol.condition.noModifierKeys(e),
+    style: new ol.Style({
+      stroke: new ol.Stroke({
         color: 'hsla(200, 70%, 90%, 0.8)',
         width: 4,
       }),
@@ -1290,8 +1257,8 @@ function generateHoverInteraction(...layers) {
 }
 
 function generateFrameLayer() {
-  const layer = new VectorLayer({
-    source: new VectorSource(),
+  const layer = new ol.VectorLayer({
+    source: new ol.VectorSource(),
   })
 
   layer.setZIndex(2)
@@ -1300,14 +1267,14 @@ function generateFrameLayer() {
 }
 
 function generateFrameFillLayer() {
-  return new VectorLayer({
-    source: new VectorSource(),
+  return new ol.VectorLayer({
+    source: new ol.VectorSource(),
   })
 }
 
 function generatePinLayer() {
-  const layer = new VectorLayer({
-    source: new VectorSource(),
+  const layer = new ol.VectorLayer({
+    source: new ol.VectorSource(),
   })
 
   layer.setZIndex(3)
@@ -1316,13 +1283,13 @@ function generatePinLayer() {
 }
 
 function generateImageryLayer() {
-  return new VectorLayer({
-    source: new VectorSource({ features: new Collection() }),
-    style: new Style({
-      fill: new Fill({
+  return new ol.VectorLayer({
+    source: new ol.VectorSource({ features: new ol.Collection() }),
+    style: new ol.Style({
+      fill: new ol.Fill({
         color: 'rgba(0, 0, 0, 0.08)',
       }),
-      stroke: new Stroke({
+      stroke: new ol.Stroke({
         color: 'rgba(0, 0, 0, 0.32)',
         width: 1,
       }),
@@ -1331,7 +1298,7 @@ function generateImageryLayer() {
 }
 
 function generateImageSearchResultsOverlay(componentRef) {
-  return new Overlay({
+  return new ol.Overlay({
     element:   findDOMNode(componentRef),
     id:        'imageSearchResults',
     stopEvent: false,
@@ -1339,7 +1306,7 @@ function generateImageSearchResultsOverlay(componentRef) {
 }
 
 function generateXYZScenePreviewSource(provider, imageId, apiKey) {
-  return new XYZ(Object.assign({}, provider, {
+  return new ol.XYZ(Object.assign({}, provider, {
     crossOrigin: 'anonymous',
     tileLoadFunction,
     url: provider.url.replace('__SCENE_ID__', imageId).replace('__API_KEY__', apiKey),
@@ -1348,7 +1315,7 @@ function generateXYZScenePreviewSource(provider, imageId, apiKey) {
 }
 
 function generateImageStaticScenePreviewSource(provider, imageId, extent, apiKey) {
-  return new ImageStatic(Object.assign({}, provider, {
+  return new ol.ImageStatic(Object.assign({}, provider, {
     crossOrigin: 'anonymous',
     imageLoadFunction: tileLoadFunction,
     projection: WEB_MERCATOR,
@@ -1358,27 +1325,27 @@ function generateImageStaticScenePreviewSource(provider, imageId, extent, apiKey
 }
 
 function generateSelectInteraction(...layers) {
-  return new Select({
+  return new ol.Select({
     layers,
     multi: true,
-    condition: e => condition.click(e) && (
-      condition.noModifierKeys(e) || condition.shiftKeyOnly(e)
+    condition: e => ol.condition.click(e) && (
+      ol.condition.noModifierKeys(e) || ol.condition.shiftKeyOnly(e)
     ),
-    style: (feature: Feature) => {
+    style: (feature: ol.Feature) => {
       switch (feature.get(KEY_TYPE)) {
         case TYPE_JOB:
-          return new Style()
+          return new ol.Style()
         default:
-          return new Style({
-            stroke: new Stroke({
+          return new ol.Style({
+            stroke: new ol.Stroke({
               color: 'black',
               width: 2,
             }),
           })
       }
     },
-    toggleCondition: condition.never,
-    filter: (feature: Feature) => {
+    toggleCondition: ol.condition.never,
+    filter: (feature: ol.Feature) => {
       return isFeatureTypeSelectable(feature)
     },
   })

--- a/src/components/StaticMinimap.tsx
+++ b/src/components/StaticMinimap.tsx
@@ -17,17 +17,7 @@
 const styles: any = require('./StaticMinimap.css')
 
 import * as React from 'react'
-import Map from 'ol/map'
-import Polygon from 'ol/geom/polygon'
-import Tile from 'ol/layer/tile'
-import VectorLayer from 'ol/layer/vector'
-import XYZ from 'ol/source/xyz'
-import VectorSource from 'ol/source/vector'
-import Feature from 'ol/feature'
-import Fill from 'ol/style/fill'
-import Stroke from 'ol/style/stroke'
-import Style from 'ol/style/style'
-import View from 'ol/view'
+import * as ol from '../utils/ol'
 
 import {BASEMAP_TILE_PROVIDERS} from '../config'
 import {deserializeBbox} from '../utils/geometries'
@@ -41,7 +31,7 @@ interface Props {
 export class StaticMinimap extends React.Component<Props, {}> {
   refs: any
 
-  private map: Map
+  private map: ol.Map
 
   componentDidMount() {
     this.initializeMap()
@@ -63,28 +53,28 @@ export class StaticMinimap extends React.Component<Props, {}> {
 
   private initializeMap() {
     const bbox = deserializeBbox(this.props.bbox)
-    const bboxGeometry = Polygon.fromExtent(bbox)
-    this.map = new Map({
+    const bboxGeometry = ol.Polygon.fromExtent(bbox)
+    this.map = new ol.Map({
       controls: [],
       interactions: [],
       layers: [
-        new Tile({
-          source: new XYZ(DEFAULT_TILE_PROVIDER),
+        new ol.Tile({
+          source: new ol.XYZ(DEFAULT_TILE_PROVIDER),
         }),
-        new VectorLayer({
-          source: new VectorSource({
+        new ol.VectorLayer({
+          source: new ol.VectorSource({
             wrapX: false,
             features: [
-              new Feature({
+              new ol.Feature({
                 geometry: bboxGeometry,
               }),
             ],
           }),
-          style: new Style({
-            fill: new Fill({
+          style: new ol.Style({
+            fill: new ol.Fill({
               color: 'hsla(202, 70%, 50%, .3)',
             }),
-            stroke: new Stroke({
+            stroke: new ol.Stroke({
               color: 'hsla(202, 70%, 50%, .7)',
               lineCap: 'square',
               lineJoin: 'square',
@@ -94,7 +84,7 @@ export class StaticMinimap extends React.Component<Props, {}> {
         }),
       ],
       target: this.refs.target,
-      view: new View({
+      view: new ol.View({
         center: [0, 0],
         zoom: 1,
         maxZoom: 6,

--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -14,21 +14,16 @@
  * limitations under the License.
  **/
 
-import proj from 'ol/proj'
-import GeoJSON from 'ol/format/geojson'
-import extent from 'ol/extent'
-import Geometry from 'ol/geom/geometry'
-import MultiPolygon from 'ol/geom/multipolygon'
-import Map from 'ol/map'
+import * as ol from '../utils/ol'
 import {WEB_MERCATOR, WGS84} from '../constants'
 
 export function getFeatureCenter(feature, featureProjection = WGS84) {
-  return extent.getCenter(featureToExtent(feature, featureProjection))
+  return ol.extent.getCenter(featureToExtent(feature, featureProjection))
 }
 
 export function bboxToExtent(bbox: number[], featureProjection = WEB_MERCATOR, dataProjection = WGS84) {
   let [minLon, minLat, maxLon, maxLat] = bbox
-  return new GeoJSON().readGeometry({type: 'Polygon', coordinates: [[
+  return new ol.GeoJSON().readGeometry({type: 'Polygon', coordinates: [[
       [minLon, minLat],
       [minLon, maxLat],
       [maxLon, maxLat],
@@ -45,7 +40,7 @@ export function featureToExtent(feature: GeoJSON.Feature<GeoJSON.Polygon>,
   return geometry.getExtent()
 }
 
-export function featureToExtentWrapped(map: Map,
+export function featureToExtentWrapped(map: ol.Map,
                                        feature: GeoJSON.Feature<GeoJSON.Polygon>,
                                        featureProjection = WEB_MERCATOR,
                                        dataProjection = WGS84) {
@@ -54,34 +49,34 @@ export function featureToExtentWrapped(map: Map,
 }
 
 export function readFeatureGeometry(feature, featureProjection = WEB_MERCATOR, dataProjection = WGS84) {
-  const reader = new GeoJSON()
+  const reader = new ol.GeoJSON()
   return reader.readGeometry(feature.geometry, {featureProjection, dataProjection})
 }
 
 export function deserializeBbox(serialized) {
   if (serialized && serialized.length === 4) {
-    return proj.transformExtent(serialized, WGS84, WEB_MERCATOR)
+    return ol.proj.transformExtent(serialized, WGS84, WEB_MERCATOR)
   }
   return null
 }
 
 export function serializeBbox(extent) {
-  const bbox = proj.transformExtent(extent, WEB_MERCATOR, WGS84)
+  const bbox = ol.proj.transformExtent(extent, WEB_MERCATOR, WGS84)
   const p1 = bbox.slice(0, 2)
   const p2 = bbox.slice(2, 4)
   return p1.concat(p2).map(truncate) as [number, number, number, number]
 }
 
 export function toGeoJSON(feature) {
-  return new GeoJSON().writeFeatureObject(feature, {
+  return new ol.GeoJSON().writeFeatureObject(feature, {
     dataProjection: WGS84,
     featureProjection: WEB_MERCATOR,
   })
 }
 
-export function getWrapIndex(map: Map, positionWgs: [number, number]) {
+export function getWrapIndex(map: ol.Map, positionWgs: [number, number]) {
   // Return an index that signifies how many full map distances the position is from the map center.
-  const mapCenter = proj.transform(map.getView().getCenter(), WEB_MERCATOR, WGS84)
+  const mapCenter = ol.proj.transform(map.getView().getCenter(), WEB_MERCATOR, WGS84)
   const distanceToMapCenter = mapCenter[0] - positionWgs[0]
 
   if (distanceToMapCenter < 0) {
@@ -91,9 +86,9 @@ export function getWrapIndex(map: Map, positionWgs: [number, number]) {
   }
 }
 
-export function extentWrapped(map: Map, extent: [number, number, number, number]) {
+export function extentWrapped(map: ol.Map, extent: [number, number, number, number]) {
   // Return an extent that's wrapped so that it follows the camera as it pans across a looping map.
-  let extentWgs = proj.transformExtent(extent, WEB_MERCATOR, WGS84)
+  let extentWgs = ol.proj.transformExtent(extent, WEB_MERCATOR, WGS84)
   const centroid = [
     (extentWgs[0] + extentWgs[2]) / 2,
     (extentWgs[1] + extentWgs[3]) / 2,
@@ -103,13 +98,13 @@ export function extentWrapped(map: Map, extent: [number, number, number, number]
   extentWgs[0] += wrapIndex * 360
   extentWgs[2] += wrapIndex * 360
 
-  return proj.transformExtent(extentWgs, WGS84, WEB_MERCATOR)
+  return ol.proj.transformExtent(extentWgs, WGS84, WEB_MERCATOR)
 }
 
-export function calculateExtent(geometry: Geometry) {
-  if (geometry instanceof MultiPolygon && crossesMeridian(geometry)) {
-    const extents = geometry.getPolygons().map(g => proj.transformExtent(g.getExtent(), WEB_MERCATOR, WGS84))
-    let [, minY, , maxY] = proj.transformExtent(geometry.getExtent(), WEB_MERCATOR, WGS84)
+export function calculateExtent(geometry: ol.Geometry) {
+  if (geometry instanceof ol.MultiPolygon && crossesMeridian(geometry)) {
+    const extents = geometry.getPolygons().map(g => ol.proj.transformExtent(g.getExtent(), WEB_MERCATOR, WGS84))
+    let [, minY, , maxY] = ol.proj.transformExtent(geometry.getExtent(), WEB_MERCATOR, WGS84)
     let width = 0
     let minX = 180
 
@@ -121,14 +116,14 @@ export function calculateExtent(geometry: Geometry) {
       }
     }
 
-    return proj.transformExtent([minX, minY, minX + width, maxY], WGS84, WEB_MERCATOR)
+    return ol.proj.transformExtent([minX, minY, minX + width, maxY], WGS84, WEB_MERCATOR)
   }
 
   return geometry.getExtent()  // Use as-is
 }
 
-export function crossesMeridian(geometry: Geometry) {
-  const [minX, , maxX] = proj.transformExtent(geometry.getExtent(), WEB_MERCATOR, WGS84)
+export function crossesMeridian(geometry: ol.Geometry) {
+  const [minX, , maxX] = ol.proj.transformExtent(geometry.getExtent(), WEB_MERCATOR, WGS84)
   return minX === -180 && maxX === 180
 }
 

--- a/src/utils/ol.ts
+++ b/src/utils/ol.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2016, RadiantBlue Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+// Do all of our OpenLayers importing here so that we can avoid polluting file namespaces.
+import Collection from 'ol/collection'
+import condition from 'ol/events/condition'
+import control from 'ol/control'
+import coordinate from 'ol/coordinate'
+import DragRotate from 'ol/interaction/dragrotate'
+import Draw from 'ol/interaction/draw'
+import extent from 'ol/extent'
+import Feature from 'ol/feature'
+import Fill from 'ol/style/fill'
+import FullScreen from 'ol/control/fullscreen'
+import GeoJSON from 'ol/format/geojson'
+import Geometry from 'ol/geom/geometry'
+import Image from 'ol/layer/image'
+import ImageStatic from 'ol/source/imagestatic'
+import interaction from 'ol/interaction'
+import LineString from 'ol/geom/linestring'
+import Map from 'ol/map'
+import MousePosition from 'ol/control/mouseposition'
+import MultiPolygon from 'ol/geom/multipolygon'
+import Overlay from 'ol/overlay'
+import Point from 'ol/geom/point'
+import Polygon from 'ol/geom/polygon'
+import proj from 'ol/proj'
+import RegularShape from 'ol/style/regularshape'
+import ScaleLine from 'ol/control/scaleline'
+import Select from 'ol/interaction/select'
+import Stroke from 'ol/style/stroke'
+import Style from 'ol/style/style'
+import Text from 'ol/style/text'
+import Tile from 'ol/layer/tile'
+import TileWMS from 'ol/source/tilewms'
+import VectorLayer from 'ol/layer/vector'
+import VectorSource from 'ol/source/vector'
+import View from 'ol/view'
+import XYZ from 'ol/source/xyz'
+import ZoomSlider from 'ol/control/zoomslider'
+
+export {Collection}
+export {condition}
+export {control}
+export {coordinate}
+export {DragRotate}
+export {Draw}
+export {extent}
+export {Feature}
+export {Fill}
+export {FullScreen}
+export {GeoJSON}
+export {Geometry}
+export {Image}
+export {ImageStatic}
+export {interaction}
+export {LineString}
+export {Map}
+export {MousePosition}
+export {MultiPolygon}
+export {Overlay}
+export {Point}
+export {Polygon}
+export {proj}
+export {RegularShape}
+export {ScaleLine}
+export {Select}
+export {Stroke}
+export {Style}
+export {Text}
+export {Tile}
+export {TileWMS}
+export {VectorLayer}
+export {VectorSource}
+export {View}
+export {XYZ}
+export {ZoomSlider}
+
+export default {
+  Collection,
+  condition,
+  control,
+  coordinate,
+  DragRotate,
+  Draw,
+  extent,
+  Feature,
+  Fill,
+  FullScreen,
+  GeoJSON,
+  Geometry,
+  Image,
+  ImageStatic,
+  interaction,
+  LineString,
+  Map,
+  MousePosition,
+  MultiPolygon,
+  Overlay,
+  Point,
+  Polygon,
+  proj,
+  RegularShape,
+  ScaleLine,
+  Select,
+  Stroke,
+  Style,
+  Text,
+  Tile,
+  TileWMS,
+  VectorLayer,
+  VectorSource,
+  View,
+  XYZ,
+  ZoomSlider,
+}


### PR DESCRIPTION
This is just to cleanup all of the variables that were being created from so many OpenLayers imports in files. They were causing naming clashes (eg. OL `Map` object clashing with the built-in JS `Map` object), confusion with ambiguous object types (eg. `Geometry`, `GeoJSON`, etc), and situations where there was accidental shadowing of imported variables (eg. `extent` was often imported and also used as a local variable name).

See what you think about this solution. It seems as if TypeScript should have a built-in way to import objects _into_ an object or namespace to avoid this issue, but the only way to import seems to be as naked variables. So I made a wrapper `utils/ol` module that takes care of the individual imports and wraps them in a single object. That way we keep the bonus of only importing the code needed by the app, but also keep the bonus of only needing a single import for the entire library, while also making library usages more explicitly scoped in code.

Again, it seems like there should be an easier solution for this. I'm really surprised (and frankly kind of appalled) that file-splitting isn't handled automatically by the compiler without requiring fine-grained imports. There must be a library that will fix the problem automatically somehow, but I couldn't find anything. So I just went ahead and brute forced it. I'd love to know if there's a better fix for this though.