### PR TITLE
Center text in subheaders vertically.

### DIFF
--- a/src/styles/menus.css
+++ b/src/styles/menus.css
@@ -49,7 +49,7 @@
 
 .submenu h2 {
   margin: 0;
-  padding: 5px 6px;
+  padding: 5px 9px 7px;
   font-size: 1.2em;
   background-color: var(--header-bgcolor);
   color: white;


### PR DESCRIPTION
Just a minor tweak to the subheader padding. I centered the text vertically a little better and also gave it a little more breathing room on the left.

### Before
![selection_073](https://user-images.githubusercontent.com/3220897/46117713-a965d800-c1b7-11e8-8216-01f50e8cd198.png)

### After
![selection_072](https://user-images.githubusercontent.com/3220897/46117717-acf95f00-c1b7-11e8-8315-1c6644b9f13f.png)
