### PR TITLE
Fix unclickable outer divots along meridian.

### DIFF
--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -22,6 +22,9 @@ import MultiPolygon from 'ol/geom/multipolygon'
 import Map from 'ol/map'
 import {WEB_MERCATOR, WGS84} from '../constants'
 
+export const WEB_MERCATOR_MIN = proj.transform([-180, -90], WGS84, WEB_MERCATOR)
+export const WEB_MERCATOR_MAX = proj.transform([180, 90], WGS84, WEB_MERCATOR)
+
 export function getFeatureCenter(feature, featureProjection = WGS84) {
   return extent.getCenter(featureToExtent(feature, featureProjection))
 }


### PR DESCRIPTION
This fixes an issue where outer divots wouldn't be clickable for jobs that lay along the meridian.

The fix for the majority of cases was to simply wrap any divots that sit outside of the -180/180 map bounds. But for some reason divots that actually straddled the meridian would only be clickable on one side of the meridian. This seems to point to some sort of configuration issue in the select interaction. However, nothing worked after trying enabling/disabling wrapX wherever I could, and setting manual extents wherever possible. So I opted for a bit of a gnarly workaround instead, where I'm just rendering divots that straddle the meridian twice - once on each side of the map. It doesn't appear to have any negative side-effects aside from some ugly code.