### PR TITLE
Proper fix for feature details overlay mouse event intercept.

### DIFF
--- a/src/components/FeatureDetails.css
+++ b/src/components/FeatureDetails.css
@@ -16,7 +16,6 @@
 
 .root {
   position: absolute;
-  pointer-events: none;
 }
 
 .sceneDetails {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -1248,6 +1248,7 @@ function generateFeatureDetailsOverlay(componentRef) {
     element:     findDOMNode(componentRef),
     id:          'featureDetails',
     positioning: 'top-left',
+    stopEvent:   false,
   })
 }
 


### PR DESCRIPTION
I just realized that OL has a built-in way of allowing mouse events to propagate through overlays. So I used that instead of css to fix the issue where feature details was stopping mouse event propagation.