### PR TITLE
Fit job metadata into job list view on expansion.

### DIFF
--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -43,6 +43,7 @@ interface Props {
   onSelectJob(job: beachfront.Job)
   onForgetJob(job: beachfront.Job)
   onNavigate(loc: { pathname: string, search: string, hash: string })
+  onToggleExpansion(job: beachfront.Job, isExpanded: boolean)
 }
 
 interface State {
@@ -269,6 +270,8 @@ export class JobStatus extends React.Component<Props, State> {
       isExpanded: !this.state.isExpanded,
       isRemoving: false,
     })
+
+    this.props.onToggleExpansion(this.props.job, !this.state.isExpanded)
   }
 }
 

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -34,6 +34,8 @@ interface Props {
 export class JobStatusList extends React.Component<Props, void> {
   constructor(props: Props) {
     super(props)
+
+    this.handleToggleExpansion = this.handleToggleExpansion.bind(this)
   }
 
   componentDidUpdate(prevProps) {
@@ -70,6 +72,7 @@ export class JobStatusList extends React.Component<Props, void> {
               onNavigate={this.props.onNavigateToJob}
               onForgetJob={this.props.onForgetJob}
               onSelectJob={this.props.onSelectJob}
+              onToggleExpansion={this.handleToggleExpansion}
               selectedFeature={this.props.selectedFeature}
             />
           ))}
@@ -78,22 +81,38 @@ export class JobStatusList extends React.Component<Props, void> {
     )
   }
 
+  private handleToggleExpansion(job: beachfront.Job, isExpanded: boolean) {
+    if (isExpanded) {
+      // Fit the metadata into view once it finishes expanding.
+      const row = document.querySelector(`.JobStatus-${job.properties.job_id}`)
+      const handleTransitionEnd = (e) => {
+        this.scrollToJob(job)
+        row.removeEventListener(e.type, handleTransitionEnd)
+      }
+      row.addEventListener('transitionend', handleTransitionEnd)
+    }
+  }
+
   private scrollToSelectedJob() {
     const job = this.props.selectedFeature as beachfront.Job
     if (job) {
-      const row = document.querySelector(`.JobStatus-${job.properties.job_id}`)
-      if (row) {
-        const offset = [
-          '.JobStatusList-root header',
-          '.ClassificationBanner-root',
-        ].reduce((rc, s) => rc + document.querySelector(s).clientHeight, 0)
+      this.scrollToJob(job)
+    }
+  }
 
-        const box = row.getBoundingClientRect()
-        const height = window.innerHeight || document.documentElement.clientHeight
+  private scrollToJob(job) {
+    const row = document.querySelector(`.JobStatus-${job.properties.job_id}`)
+    if (row) {
+      const offset = [
+        '.JobStatusList-root header',
+        '.ClassificationBanner-root',
+      ].reduce((rc, s) => rc + document.querySelector(s).clientHeight, 0)
 
-        if (Math.floor(box.top) <= offset || box.bottom > height - row.clientHeight) {
-          row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-        }
+      const box = row.getBoundingClientRect()
+      const height = window.innerHeight || document.documentElement.clientHeight
+
+      if (Math.floor(box.top) <= offset || box.bottom > height - row.clientHeight) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
       }
     }
   }


### PR DESCRIPTION
This fixes an issue where job metadata would expand outside of the view when expanded near the bottom of the job list. The job list should automatically scroll to fit the metadata on expansion now.