### PR TITLE
Fix User Tour Selector

### DIFF
--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -425,7 +425,7 @@ export class UserTour extends React.Component<any, any> {
       },
       {
         step: 13,
-        selector: '.AlgorithmList-root',
+        selector: '.AlgorithmList-root h2',
         position: 'right',
         horizontalOffset: 8,
         verticalOffset: -10,


### PR DESCRIPTION
THe user tour plugin, based on using the selector for the entire Algorithm section, was not trusting that that section was in view, and thus the tour would time out.

This change updates the selector for that step to instead ensure that the header is in view.