### PR TITLE
Fix clunky job status collapse animation.

### DIFF
--- a/src/components/JobStatus.css
+++ b/src/components/JobStatus.css
@@ -239,16 +239,6 @@
   max-height: 400px;
 }
 
-.removeToggle button,
-.removeWarning button {
-  display: none;
-}
-
-.isExpanded .removeToggle button,
-.isRemoving .removeWarning button {
-  display: inline-block;
-}
-
 .removeToggle {
   margin-bottom: var(--padding-size);
 }


### PR DESCRIPTION
"Remove this Job" was being hidden separately from the animation, creating a clunky collapse effect. It should look smooth now.

(animations are slowed to 25% to clearly illustrate the issue)

### Before
![peek 2018-10-04 02-35](https://user-images.githubusercontent.com/3220897/46465943-d51c2b80-c77e-11e8-8e6a-c444e99405ae.gif)

### After
![peek 2018-10-04 02-36](https://user-images.githubusercontent.com/3220897/46465952-d8afb280-c77e-11e8-8d9e-13d70b127957.gif)
