### PR TITLE
Fix lag when switching to jobs list with lots of jobs.

### DIFF
--- a/src/components/Application.css
+++ b/src/components/Application.css
@@ -21,3 +21,8 @@
   right: 0;
   bottom: 0;
 }
+
+.hidden {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -216,6 +216,7 @@ export class Application extends React.Component<Props, State> {
       '/product-lines',
       '/create-product-line',
     ]
+    const showJobsStatusList = (this.state.route.pathname === '/jobs')
     const shrunk = allowedEndpoints.indexOf(this.state.route.pathname) > -1
     return (
       <div className={styles.root}>
@@ -249,6 +250,17 @@ export class Application extends React.Component<Props, State> {
           onSelectFeature={this.handleSelectFeature}
           onViewChange={mapView => this.setState({ mapView })}
           onSignOutClick={this.handleSignOutClick}
+        />
+        <JobStatusList
+          className={(showJobsStatusList) ? '' : styles.hidden}
+          activeIds={this.state.detections.map(d => d.id)}
+          error={this.state.jobs.error}
+          jobs={this.state.jobs.records}
+          onDismissError={this.handleDismissJobError}
+          onForgetJob={this.handleForgetJob}
+          onNavigateToJob={this.handleNavigateToJob}
+          onSelectJob={this.handleSelectFeature}
+          selectedFeature={this.state.selectedFeature}
         />
         {this.renderRoute()}
         {this.state.isSessionExpired && (
@@ -331,18 +343,11 @@ export class Application extends React.Component<Props, State> {
           />
         )
       case '/jobs':
-        return (
-          <JobStatusList
-            activeIds={this.state.detections.map(d => d.id)}
-            error={this.state.jobs.error}
-            jobs={this.state.jobs.records}
-            onDismissError={this.handleDismissJobError}
-            onForgetJob={this.handleForgetJob}
-            onNavigateToJob={this.handleNavigateToJob}
-            onSelectJob={this.handleSelectFeature}
-            selectedFeature={this.state.selectedFeature}
-          />
-        )
+        /*
+          JobsStatusList can take a long time to recreate with lots of jobs, so never destroy it. Instead, just modify
+          its visibility/events styling based on the current route.
+        */
+        return null
       case '/product-lines':
         return (
           <ProductLineList

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -93,6 +93,7 @@ interface State {
   map?: ol.Map
   mapMode?: string
   detections?: (beachfront.Job | beachfront.ProductLine)[]
+  activeIds?: {[id: string]: boolean}
   frames?: (beachfront.Job | beachfront.ProductLine)[]
   bbox?: [number, number, number, number]
   mapView?: MapView
@@ -251,17 +252,18 @@ export class Application extends React.Component<Props, State> {
           onViewChange={mapView => this.setState({ mapView })}
           onSignOutClick={this.handleSignOutClick}
         />
-        <JobStatusList
-          className={(showJobsStatusList) ? '' : styles.hidden}
-          activeIds={this.state.detections.map(d => d.id)}
-          error={this.state.jobs.error}
-          jobs={this.state.jobs.records}
-          onDismissError={this.handleDismissJobError}
-          onForgetJob={this.handleForgetJob}
-          onNavigateToJob={this.handleNavigateToJob}
-          onSelectJob={this.handleSelectFeature}
-          selectedFeature={this.state.selectedFeature}
-        />
+        <div className={(showJobsStatusList) ? '' : styles.hidden}>
+          <JobStatusList
+            activeIds={this.state.activeIds}
+            error={this.state.jobs.error}
+            jobs={this.state.jobs.records}
+            onDismissError={this.handleDismissJobError}
+            onForgetJob={this.handleForgetJob}
+            onNavigateToJob={this.handleNavigateToJob}
+            onSelectJob={this.handleSelectFeature}
+            selectedFeature={this.state.selectedFeature}
+          />
+        </div>
         {this.renderRoute()}
         {this.state.isSessionExpired && (
           <SessionExpired
@@ -395,7 +397,7 @@ export class Application extends React.Component<Props, State> {
   }
 
   private updateDetections() {
-    let detections: beachfront.Job[] | beachfront.ProductLine[]
+    let detections: (beachfront.Job | beachfront.ProductLine)[]
     switch (this.state.route.pathname) {
       case '/create-product-line':
       case '/product-lines':
@@ -419,7 +421,13 @@ export class Application extends React.Component<Props, State> {
     }
 
     if (detectionsChanged) {
-      this.setState({ detections })
+      const activeIds = {}
+      detections.forEach(d => activeIds[d.id] = true)
+
+      this.setState({
+        detections,
+        activeIds,
+      })
     }
   }
 
@@ -851,6 +859,7 @@ function generateInitialState(): State {
     // Map state
     mapMode: MODE_NORMAL,
     detections: [],
+    activeIds: {},
     frames: [],
     bbox: null,
     mapView: null,

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -21,6 +21,7 @@ import {JobStatus} from './JobStatus'
 import * as moment from 'moment'
 
 interface Props {
+  className?: string
   activeIds: string[]
   error: any
   jobs: beachfront.Job[]
@@ -46,7 +47,7 @@ export class JobStatusList extends React.Component<Props, void> {
 
   render() {
     return (
-      <div className={`${styles.root} ${!this.props.jobs.length ? styles.isEmpty : ''}`}>
+      <div className={`${styles.root} ${!this.props.jobs.length ? styles.isEmpty : ''} ${this.props.className}`}>
         <header>
           <h1>Jobs</h1>
         </header>

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -21,8 +21,7 @@ import {JobStatus} from './JobStatus'
 import * as moment from 'moment'
 
 interface Props {
-  className?: string
-  activeIds: string[]
+  activeIds: {[id: string]: boolean}
   error: any
   jobs: beachfront.Job[]
   selectedFeature: beachfront.Job | beachfront.Scene
@@ -39,6 +38,18 @@ export class JobStatusList extends React.Component<Props, void> {
     this.handleToggleExpansion = this.handleToggleExpansion.bind(this)
   }
 
+  shouldComponentUpdate(nextProps: Props) {
+    let shouldUpdate = false
+
+    Object.keys(this.props).forEach((key) => {
+      if (nextProps[key] !== this.props[key]) {
+        shouldUpdate = true
+      }
+    })
+
+    return shouldUpdate
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.selectedFeature !== prevProps.selectedFeature) {
       this.scrollToSelectedJob()
@@ -47,7 +58,7 @@ export class JobStatusList extends React.Component<Props, void> {
 
   render() {
     return (
-      <div className={`${styles.root} ${!this.props.jobs.length ? styles.isEmpty : ''} ${this.props.className}`}>
+      <div className={`${styles.root} ${!this.props.jobs.length ? styles.isEmpty : ''}`}>
         <header>
           <h1>Jobs</h1>
         </header>
@@ -68,7 +79,7 @@ export class JobStatusList extends React.Component<Props, void> {
           }).map(job => (
             <JobStatus
               key={job.id}
-              isActive={this.props.activeIds.includes(job.id)}
+              isActive={job.id in this.props.activeIds}
               job={job}
               onNavigate={this.props.onNavigateToJob}
               onForgetJob={this.props.onForgetJob}


### PR DESCRIPTION
I made the jobs list stay rendered, only hiding it and stopping pointer events when the route isn't `/jobs`. It should feel much more snappy navigating back and forth from Create Job to Jobs now when you have tons of jobs. This fix should scale to any number of jobs as well. There is a slight hit to overall rendering performance on views other than the jobs list, since the jobs list is always being rendered invisibly, but I definitely think it's worth the trade off. I tried using `display` and `visibility` styling instead of `opacity` for the jobs list, but they created some weird visual glitches where elements would pop back in as you switched to that view.

This is a little bit of a hack rather than a true optimization, but I'm not sure if any simple optimization will make mounting/rendering of the jobs list fast enough to feel really responsive with lots of jobs. Creating and rendering a list with hundreds of UI-rich items is likely to take some time regardless.

We could potentially look into more complex solutions to this problem, since trying to render any list with that many items probably isn't great to begin with. I looked into using a virtual list, where only the visible rows are actually rendered in the dom, but there are technical issues related to our dynamic row heights that make it impractical at the moment. You need to know the height of every row beforehand in order to use a virtual list, but we let our rows expand based on the content. If we wanted to use a virtual list then we would have to come up with a design solution that allows us to specify an explicit height for each row.