### PR TITLE
Add Seed Job Reference

### DIFF
--- a/beachfront.d.ts
+++ b/beachfront.d.ts
@@ -33,6 +33,7 @@ declare namespace beachfront {
 
     interface JobProperties {
       job_id: string
+      seed_job_id: string
       name: string
       status: string
       created_by: string

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -1180,9 +1180,18 @@ function generateDetectionsSource(wmsUrl, feature: beachfront.Job|beachfront.Pro
     projection: WEB_MERCATOR,
     params: {
       [KEY_LAYERS]: IDENTIFIER_DETECTIONS,
-      [KEY_ENV]: (feature.properties.type === TYPE_JOB ? 'jobid:' : 'productlineid:') + feature.id,  // HACK
+      [KEY_ENV]: (feature.properties.type === TYPE_JOB ? 'jobid:' : 'productlineid:') + getIdForFeature(feature),  // HACK
     },
   })
+}
+
+function getIdForFeature(feature: beachfront.Job|beachfront.ProductLine) {
+  // If this is a Job that contains a Seed Job reference, use that Seed Job ID to get the detections
+  const job = (feature as beachfront.Job)
+  if ((job) && (job.properties.seed_job_id)) {
+    return job.properties.seed_job_id
+  }
+  return feature.id
 }
 
 function generateDrawLayer() {


### PR DESCRIPTION
Some jobs in Beachfront are created with identical parameters to historical jobs run by other users. In these cases, the detection isn't re-generated and the results from the previous historical job are used as the results for the newly submitted job. 

Previously this worked because the identical Job was copied over into the new users queue. However, this caused a problem with metadata that was producing unexpected results (the newly submitted users job would have "incorrect to them" date stamps, and any custom naming for that job would be disregarded in favor of the historical jobs name. the date stamps would match the original jobs, not the newly submitted ones). 

Now every Job that is created gets a unique Job object, even if it is identical to a historical Job. This ensures that proper metadata is created for each and every job request. A new field is added to Jobs that are redundant to historical jobs called "seed_job_id" that provides a reference to the historical detection results. In this way, we can still reference historical detections while still maintaining proper metadata for every job. 