### PR TITLE
Preview Sticks after Job is Removed

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -562,6 +562,7 @@ export class Application extends React.Component<Props, State> {
   private handleForgetJob(job: beachfront.Job) {
     this.setState({
       jobs: this.state.jobs.$filter(j => j.id !== job.id),
+      selectedFeature: null,
     })
     if (this.state.route.jobIds.includes(job.id)) {
       this.navigateTo({

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -563,13 +563,15 @@ export class Application extends React.Component<Props, State> {
     this.setState({
       jobs: this.state.jobs.$filter(j => j.id !== job.id),
       selectedFeature: null,
+    }, function() {
+      if (this.state.route.jobIds.includes(job.id)) {
+        this.navigateTo({
+          pathname: this.state.route.pathname,
+          search: this.state.route.search.replace(new RegExp('\\??jobId=' + job.id), ''),
+        })
+      }
     })
-    if (this.state.route.jobIds.includes(job.id)) {
-      this.navigateTo({
-        pathname: this.state.route.pathname,
-        search: this.state.route.search.replace(new RegExp('\\??jobId=' + job.id), ''),
-      })
-    }
+
     jobsService.forgetJob(job.id)
       .catch(() => {
         this.setState({


### PR DESCRIPTION
When removing a Job that is currently selected with its imagery displayed, that imagery preview will not be removed from the map. This is because there are two conflicting state changes occurring in the `handleForgetJob` handler.

By moving the second state change into a callback that is only triggered when the first state changed has taken effect, we can ensure that no "stomping" of state occurs, while still applying our state changes as quickly as we are able. 