### PR TITLE
Injected GeoServer Configuration

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -178,6 +178,8 @@ node {
           sh """
             cf set-env ${appName} SPACE ${env.PHASE_ONE_PCF_SPACE}
             cf set-env ${appName} DOMAIN ${env.PHASE_ONE_PCF_DOMAIN}
+            cf set-env ${appName} GEOSERVER_WORKSPACE_NAME ${env.GEOSERVER_WORKSPACE_NAME}
+            cf set-env ${appName} GEOSERVER_LAYERGROUP_NAME ${env.GEOSERVER_LAYERGROUP_NAME}
           """
           sh "cf start ${appName}"
         } catch (Exception e) {
@@ -254,6 +256,8 @@ node {
             sh """					
               cf set-env ${appName} SPACE ${env.PHASE_TWO_PCF_SPACE}
               cf set-env ${appName} DOMAIN ${env.PHASE_TWO_PCF_DOMAIN}
+              cf set-env ${appName} GEOSERVER_WORKSPACE_NAME ${env.GEOSERVER_WORKSPACE_NAME}
+              cf set-env ${appName} GEOSERVER_LAYERGROUP_NAME ${env.GEOSERVER_LAYERGROUP_NAME}
             """
             sh "cf start ${appName}"
           } catch (Exception e) {

--- a/JenkinsFile.Promote
+++ b/JenkinsFile.Promote
@@ -82,6 +82,8 @@ node {
     try {
         sh "cf set-env ${appName} SPACE ${env.PROMOTE_SPACE}"
         sh "cf set-env ${appName} DOMAIN ${env.PROMOTE_DOMAIN}"
+        sh "cf set-env ${appName} GEOSERVER_WORKSPACE_NAME ${env.GEOSERVER_WORKSPACE_NAME}"
+        sh "cf set-env ${appName} GEOSERVER_LAYERGROUP_NAME ${env.GEOSERVER_LAYERGROUP_NAME}"
         sh "cf start ${appName}"
       } catch (Exception e) {
         try {

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npm run build
 | `CLASSIFICATION_BANNER_TEXT`       | A text value for the classification banner. |
 | `CONSENT_BANNER_TEXT`              | A text value for the consent message shown at the login prompt. |
 | `USER_GUIDE_URL`                   | A URL pointing to the Beachfront user guide.  The menu guide icon will only display if this is set. |
+| `GEOSERVER_WORKSPACE_NAME`         | The Workspace name on GeoServer to load the detections preview layers from. |
+| `GEOSERVER_LAYERGROUP_NAME`        | The Layer Group name on GeoServer that references the styled detections preview layers. |
 
 ## Testing
 

--- a/beachfront.d.ts
+++ b/beachfront.d.ts
@@ -109,6 +109,8 @@ interface BuildEnvironment {
   OSM_BASE_URL: string
   PLANET_BASE_URL: string
   USER_GUIDE_URL: string
+  GEOSERVER_WORKSPACE_NAME: string
+  GEOSERVER_LAYERGROUP_NAME: string
 }
 
 declare const process: {

--- a/src/components/PrimaryMap.tsx
+++ b/src/components/PrimaryMap.tsx
@@ -48,6 +48,8 @@ import {wrap} from '../utils/math'
 import {
   BASEMAP_TILE_PROVIDERS,
   SCENE_TILE_PROVIDERS,
+  GEOSERVER_WORKSPACE_NAME,
+  GEOSERVER_LAYERGROUP_NAME,
 } from '../config'
 import {
   STATUS_ACTIVE,
@@ -73,7 +75,7 @@ const MAX_ZOOM = 22
 const RESOLUTION_CLOSE = 850
 const VIEW_BOUNDS: [number, number, number, number] = [-Number.MAX_SAFE_INTEGER, -90, Number.MAX_SAFE_INTEGER, 90]
 const STEM_OFFSET = 10000
-const IDENTIFIER_DETECTIONS = 'piazza:bfdetections'
+const IDENTIFIER_DETECTIONS = GEOSERVER_WORKSPACE_NAME + ':' + GEOSERVER_LAYERGROUP_NAME
 const KEY_SCENE_ID = 'SCENE_ID'
 const KEY_LAYERS = 'LAYERS'
 const KEY_NAME = 'name'

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,8 @@ export const CLASSIFICATION_BANNER_TEXT       = process.env.CLASSIFICATION_BANNE
 export const OSM_BASE_URL                     = process.env.OSM_BASE_URL
 export const PLANET_BASE_URL                  = process.env.PLANET_BASE_URL
 export const USER_GUIDE_URL                   = process.env.USER_GUIDE_URL
+export const GEOSERVER_WORKSPACE_NAME         = process.env.GEOSERVER_WORKSPACE_NAME
+export const GEOSERVER_LAYERGROUP_NAME        = process.env.GEOSERVER_LAYERGROUP_NAME
 
 export const API_ROOT = process.env.API_ROOT + (process.env.API_ROOT.endsWith('/') ? '' : '/')
 export const CONSENT_BANNER_TEXT = {__html: process.env.CONSENT_BANNER_TEXT}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,6 +129,8 @@ module.exports = {
       'process.env.OSM_BASE_URL': JSON.stringify(process.env.OSM_BASE_URL || 'osm.geointservices.io'),
       'process.env.PLANET_BASE_URL': JSON.stringify(process.env.PLANET_BASE_URL || 'planet.com'),
       'process.env.USER_GUIDE_URL': '"https://" + location.hostname.replace("beachfront", "bf-docs")',
+      'process.env.GEOSERVER_WORKSPACE_NAME': JSON.stringify(process.env.GEOSERVER_WORKSPACE_NAME || 'piazza'),
+      'process.env.GEOSERVER_LAYERGROUP_NAME': JSON.stringify(process.env.GEOSERVER_LAYERGROUP_NAME || 'bfdetections'),
     }),
     new HtmlWebpackPlugin({
       template: 'src/index.html',


### PR DESCRIPTION
In order to enable Beachfront to be flexible enough to use a single GeoServer for multiple deployments, the names of every GeoServer object created and referenced must be injected by configuration.

BF-UI referenced the workspace and the Layer Group by explicit name. This moves the naming into the environment variables (with suitable defaults) to allow the environment to change the GeoServer objects at will. 