### PR TITLE
Fix disappearing UI when uncaught exception occurs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4121,12 +4121,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4141,17 +4143,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4268,7 +4273,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4280,6 +4286,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4294,6 +4301,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4301,12 +4309,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4325,6 +4335,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4405,7 +4416,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4417,6 +4429,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4538,6 +4551,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/ErrorBoundary.css
+++ b/src/components/ErrorBoundary.css
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018, RadiantBlue Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.root {
+  padding: 4rem;
+}
+
+.root * {
+  color: white;
+  white-space: pre-wrap;
+}
+
+.header {
+  font-weight: bold;
+  font-size: 2.5rem;
+  margin-bottom: 2rem;
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018, RadiantBlue Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const styles: any = require('./ErrorBoundary.css')
+
+import * as React from 'react'
+
+type Info = {
+  componentStack: string
+}
+
+type Props = {
+  message?: string
+}
+
+type State = {
+  hasError: boolean
+  error: Error | null
+  info: Info | null
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      hasError: false,
+      error: null,
+      info: null,
+    }
+  }
+
+  componentDidCatch(error: Error, info: Info) {
+    // You can also log the error to an error reporting service
+    this.setState({
+      hasError: true,
+      error,
+      info,
+    })
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    // Error fallback UI.
+    return (
+      <div className={styles.root}>
+        <div className={styles.section}>
+          <h1>{this.props.message || 'Something broke.'}</h1>
+        </div>
+
+        <br/><br/>
+
+        {this.state.error && (
+          <div className={styles.section}>
+            <h1 className={styles.header}>Uncaught Exception</h1>
+            <h2>{this.state.error.stack}</h2>
+          </div>
+        )}
+
+        <br/><br/>
+
+        {this.state.info && (
+          <div className={styles.section}>
+            <h1 className={styles.header}>Component Stack</h1>
+            <h2>{this.state.info.componentStack.trim()}</h2>
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,12 +30,15 @@ import {render} from 'react-dom'
 import {Provider} from 'react-redux'
 import Application from './components/Application'
 import store from './store'
+import {ErrorBoundary} from './components/ErrorBoundary'
 
 const root = document.createElement('div')
 document.body.appendChild(root)
 render(
-  <Provider store={store}>
-    <Application />
-  </Provider>,
+  <ErrorBoundary message={'An uncaught exception has occurred. Please contact the Beachfront team for technical support.'}>
+    <Provider store={store}>
+      <Application />
+    </Provider>
+  </ErrorBoundary>,
   root,
 )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const __environment__ = process.env.NODE_ENV || 'development'
 const COMPILER_TARGET = process.env.COMPILER_TARGET || (__environment__ === 'development' ? 'es6' : 'es5')
 
 module.exports = {
-  devtool: '#cheap-module-eval-source-map',
+  devtool: 'cheap-module-source-map',
 
   context: __dirname,
   entry: './src/index.tsx',


### PR DESCRIPTION
There was a change in React 16 where they stopped allowing uncaught exceptions to occur passively. Instead, when an exception is uncaught, React now automatically wipes out the DOM and allows you to provide some fallback UI. This can be localized to individual elements of the UI if we so choose to allow the rest of the app to continue functioning despite an error in a minor component. For now, I've added a single error boundary around the entire app that has fallback UI that displays the exception stack and the component stack.

I'm a little annoyed by this change in React. The reasoning behind it is understandable; the idea being to avoid the possibility of erroneous UI states that could cause propagating errors and corrupted data. But it would be nice if it was an optional behavior. Sometimes you don't want to be stopped dead in your tracks during development due to some exception. Hopefully it will at least help us track down weird or subtle errors a little more easily. Anyways, here's their breakdown of the change and the logic behind it...

https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html

### Before
![selection_089](https://user-images.githubusercontent.com/3220897/49688408-4d2c0800-fac6-11e8-8e69-1e0266ad4692.png)

### After
![selection_090](https://user-images.githubusercontent.com/3220897/49688412-51f0bc00-fac6-11e8-852c-50c6a9148f78.png)

