### PR TITLE
Fix incorrect text in jobs list during initial load.

### DIFF
--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -68,7 +68,11 @@ export class JobStatusList extends React.Component<Props, State> {
             </li>
           )}
 
-          {!this.props.jobs.records.length ? (
+          {!this.props.jobs.initialFetchComplete && (
+            <li className={styles.placeholder}>Loading...</li>
+          )}
+
+          {this.props.jobs.initialFetchComplete && !this.props.jobs.records.length ? (
             <li className={styles.placeholder}>You haven't started any Jobs yet</li>
           ) : this.props.jobs.records.sort((job1, job2) => {
             return moment(job1.properties.created_on).isBefore(job2.properties.created_on) ? 1 : -1

--- a/src/reducers/jobsReducer.ts
+++ b/src/reducers/jobsReducer.ts
@@ -20,6 +20,7 @@ export type JobsState = {
   records: beachfront.Job[]
   isFetching: boolean
   fetchError: any
+  initialFetchComplete: boolean
   isFetchingOne: boolean
   fetchOneError: any
   lastOneFetched: beachfront.Job | null
@@ -35,6 +36,7 @@ export const jobsInitialState = {
   records: Array<beachfront.Job>(),
   isFetching: false,
   fetchError: null,
+  initialFetchComplete: false,
   isFetchingOne: false,
   fetchOneError: null,
   lastOneFetched: null,
@@ -59,6 +61,7 @@ export function jobsReducer(state = jobsInitialState, action: any) {
         ...state,
         isFetching: false,
         records: action.records,
+        initialFetchComplete: true,
       }
     case jobsTypes.JOBS_FETCH_ERROR:
       return {

--- a/test/reducers/jobsReducer.test.ts
+++ b/test/reducers/jobsReducer.test.ts
@@ -52,6 +52,7 @@ describe('jobsReducer', () => {
       ...state,
       isFetching: false,
       records: action.records,
+      initialFetchComplete: true,
     })
   })
 


### PR DESCRIPTION
The jobs list would incorrectly state "You haven't started any jobs yet" briefly during the initial load regardless of whether you actually have any jobs or not.

### Before
![selection_091](https://user-images.githubusercontent.com/3220897/49688484-d132bf80-fac7-11e8-95f8-a0de40df2dfc.png)

### After
![selection_092](https://user-images.githubusercontent.com/3220897/49688485-d4c64680-fac7-11e8-85ac-1a13f32a11f2.png)
