### PR TITLE
Fix error on tour start.

### DIFF
--- a/beachfront.d.ts
+++ b/beachfront.d.ts
@@ -138,3 +138,7 @@ interface String {
 interface Array<T> {
   includes(value: any, fromIndex?: number): boolean
 }
+
+type ActionTypes = {[key: string]: string}
+
+declare module 'redux-thunk'

--- a/src/actions/algorithmsActions.ts
+++ b/src/actions/algorithmsActions.ts
@@ -20,7 +20,7 @@ import {getClient} from '../api/session'
 import {AppState} from '../store'
 import {algorithmsInitialState, AlgorithmsState} from '../reducers/algorithmsReducer'
 
-export const algorithmsTypes = {
+export const algorithmsTypes: ActionTypes = {
   ALGORITHMS_FETCHING: 'ALGORITHMS_FETCHING',
   ALGORITHMS_FETCH_SUCCESS: 'ALGORITHMS_FETCH_SUCCESS',
   ALGORITHMS_FETCH_ERROR: 'ALGORITHMS_FETCH_ERROR',

--- a/src/actions/apiStatusActions.ts
+++ b/src/actions/apiStatusActions.ts
@@ -19,7 +19,7 @@ import {getClient} from '../api/session'
 import {AppState} from '../store'
 import {apiStatusInitialState, ApiStatusState} from '../reducers/apiStatusReducer'
 
-export const apiStatusTypes = {
+export const apiStatusTypes: ActionTypes = {
   API_STATUS_FETCHING: 'API_STATUS_FETCHING',
   API_STATUS_FETCH_SUCCESS: 'API_STATUS_FETCH_SUCCESS',
   API_STATUS_FETCH_ERROR: 'API_STATUS_FETCH_ERROR',

--- a/src/actions/catalogActions.ts
+++ b/src/actions/catalogActions.ts
@@ -21,7 +21,7 @@ import {getClient} from '../api/session'
 import {wrap} from '../utils/math'
 import {catalogInitialState, CatalogState} from '../reducers/catalogReducer'
 
-export const catalogTypes = {
+export const catalogTypes: ActionTypes = {
   CATALOG_INITIALIZING: 'CATALOG_INITIALIZING',
   CATALOG_INITIALIZE_SUCCESS: 'CATALOG_INITIALIZE_SUCCESS',
   CATALOG_INITIALIZE_ERROR: 'CATALOG_INITIALIZE_ERROR',

--- a/src/actions/jobsActions.ts
+++ b/src/actions/jobsActions.ts
@@ -19,7 +19,7 @@ import {getClient} from '../api/session'
 import {JOB_ENDPOINT} from '../config'
 import {JobsState} from '../reducers/jobsReducer'
 
-export const jobsTypes = {
+export const jobsTypes: ActionTypes = {
   JOBS_FETCHING: 'JOBS_FETCHING',
   JOBS_FETCH_SUCCESS: 'JOBS_FETCH_SUCCESS',
   JOBS_FETCH_ERROR: 'JOBS_FETCH_ERROR',

--- a/src/actions/mapActions.ts
+++ b/src/actions/mapActions.ts
@@ -21,7 +21,7 @@ import {Extent, Point} from '../utils/geometries'
 import {Dispatch} from 'redux'
 import {MapCollections, MapState} from '../reducers/mapReducer'
 
-export const mapTypes = {
+export const mapTypes: ActionTypes = {
   MAP_INITIALIZED: 'MAP_INITIALIZED',
   MAP_MODE_UPDATED: 'MAP_MODE_UPDATED',
   MAP_DETECTIONS_UPDATED: 'MAP_DETECTIONS_UPDATED',

--- a/src/actions/productLinesActions.ts
+++ b/src/actions/productLinesActions.ts
@@ -20,7 +20,7 @@ import {JOB_ENDPOINT, PRODUCTLINE_ENDPOINT} from '../config'
 import {Extent} from '../utils/geometries'
 import {ProductLinesState} from '../reducers/productLinesReducer'
 
-export const productLinesTypes = {
+export const productLinesTypes: ActionTypes = {
   PRODUCT_LINES_FETCHING: 'PRODUCT_LINES_FETCHING',
   PRODUCT_LINES_FETCH_SUCCESS: 'PRODUCT_LINES_FETCH_SUCCESS',
   PRODUCT_LINES_FETCH_ERROR: 'PRODUCT_LINES_FETCH_ERROR',

--- a/src/actions/routeActions.ts
+++ b/src/actions/routeActions.ts
@@ -16,7 +16,7 @@
 
 import {generateRoute} from '../utils/routeUtils'
 
-export const routeTypes = {
+export const routeTypes: ActionTypes = {
   ROUTE_CHANGED: 'ROUTE_CHANGED',
 }
 

--- a/src/actions/tourActions.ts
+++ b/src/actions/tourActions.ts
@@ -19,7 +19,7 @@ import {scrollIntoView} from '../utils/domUtils'
 import {AppState} from '../store'
 import {TourState} from '../reducers/tourReducer'
 
-export const tourTypes = {
+export const tourTypes: ActionTypes = {
   TOUR_STEPS_UPDATED: 'TOUR_STEPS_UPDATED',
   TOUR_STARTED: 'TOUR_STARTED',
   TOUR_ENDED: 'TOUR_ENDED',

--- a/src/actions/tourActions.ts
+++ b/src/actions/tourActions.ts
@@ -98,7 +98,7 @@ export const tourActions = {
 
         dispatch({
           type: tourTypes.TOUR_STEP_CHANGE_ERROR,
-          error: error.message,
+          error,
         })
 
         return

--- a/src/actions/userActions.ts
+++ b/src/actions/userActions.ts
@@ -19,7 +19,7 @@ import {getClient} from '../api/session'
 import {AppState} from '../store'
 import {userInitialState, UserState} from '../reducers/userReducer'
 
-export const userTypes = {
+export const userTypes: ActionTypes = {
   USER_LOGGED_OUT: 'USER_LOGGED_OUT',
   USER_SESSION_CLEARED: 'USER_SESSION_CLEARED',
   USER_SESSION_LOGGED_OUT: 'USER_SESSION_LOGGED_OUT',

--- a/src/components/UserTour.tsx
+++ b/src/components/UserTour.tsx
@@ -51,13 +51,13 @@ const SourceName = (props: any) => {
 }
 
 const UserTourErrorMessage = (props: {
-  message: string,
-  tour: UserTour,
+  error: Error | null,
+  onDismiss: () => any
 }) => {
-  return props.message ? <div className={styles.error}>
-    <div className={styles.close} title="Dismiss" onClick={props.tour.props.actions.tour.end}>&times;</div>
+  return props.error ? <div className={styles.error}>
+    <div className={styles.close} title="Dismiss" onClick={props.onDismiss}>&times;</div>
     <div className={styles.header}>Oops!</div>
-    <div className={styles.message}>{props.message}</div>
+    <div className={styles.message}>{props.error.message}</div>
   </div> : null
 }
 
@@ -622,7 +622,7 @@ export class UserTour extends React.Component<Props> {
             steps={this.props.tour.steps}
           />
         </div>
-        <UserTourErrorMessage message={this.props.tour.error || 'An unknown error occurred.'} tour={this}/>
+        <UserTourErrorMessage error={this.props.tour.error} onDismiss={this.props.actions.tour.end}/>
       </div>
     )
   }

--- a/src/reducers/tourReducer.ts
+++ b/src/reducers/tourReducer.ts
@@ -20,7 +20,7 @@ export interface TourState {
   inProgress: boolean
   changing: boolean
   step: number
-  error: string | null
+  error: Error | null
   steps: TourStep[]
 }
 

--- a/test/actions/tourActions.test.ts
+++ b/test/actions/tourActions.test.ts
@@ -136,13 +136,11 @@ describe('tourActions', () => {
 
       await store.dispatch(tourActions.goToStep(2) as any)
 
-      expect(store.getActions()).toEqual([
-        { type: tourTypes.TOUR_STEP_CHANGING },
-        {
-          type: tourTypes.TOUR_STEP_CHANGE_ERROR,
-          error: 'after error',
-        },
-      ])
+      const actions = store.getActions()
+      expect(actions.length).toEqual(2)
+      expect(actions[0]).toEqual({ type: tourTypes.TOUR_STEP_CHANGING })
+      expect(actions[1].type).toEqual(tourTypes.TOUR_STEP_CHANGE_ERROR)
+      expect(actions[1].error).toEqual(expect.objectContaining({ message: 'after error' }))
     })
 
     test('"before" callback error', async () => {
@@ -168,13 +166,11 @@ describe('tourActions', () => {
 
       await store.dispatch(tourActions.goToStep(2) as any)
 
-      expect(store.getActions()).toEqual([
-        { type: tourTypes.TOUR_STEP_CHANGING },
-        {
-          type: tourTypes.TOUR_STEP_CHANGE_ERROR,
-          error: 'before error',
-        },
-      ])
+      const actions = store.getActions()
+      expect(actions.length).toEqual(2)
+      expect(actions[0]).toEqual({ type: tourTypes.TOUR_STEP_CHANGING })
+      expect(actions[1].type).toEqual(tourTypes.TOUR_STEP_CHANGE_ERROR)
+      expect(actions[1].error).toEqual(expect.objectContaining({ message: 'before error' }))
     })
 
     test('do nothing if already changing steps', async () => {
@@ -200,7 +196,7 @@ describe('tourActions', () => {
             {
               step: 1,
               before: () => {
-                throw Error('error')
+                throw Error('before error')
               },
             },
             { step: 2 },
@@ -215,13 +211,11 @@ describe('tourActions', () => {
 
       expect(alertSpy.callCount).toEqual(1)
 
-      expect(store.getActions()).toEqual([
-        { type: tourTypes.TOUR_STEP_CHANGING },
-        {
-          type: tourTypes.TOUR_STEP_CHANGE_ERROR,
-          error: 'error',
-        },
-      ])
+      const actions = store.getActions()
+      expect(actions.length).toEqual(2)
+      expect(actions[0]).toEqual({ type: tourTypes.TOUR_STEP_CHANGING })
+      expect(actions[1].type).toEqual(tourTypes.TOUR_STEP_CHANGE_ERROR)
+      expect(actions[1].error).toEqual(expect.objectContaining({ message: 'before error' }))
 
       alertSpy.restore()
     })


### PR DESCRIPTION
This was being caused by a bad bit of logic that was making it think there was always an error even when there wasn't.

You may still see an exception in the console when you start the tour, but it's actually unrelated to this issue. That exception is some kind of internal error in the tour library, which doesn't have any clear fix as far as I can tell. It seems to be completely harmless though.

![selection_093](https://user-images.githubusercontent.com/3220897/49887554-87ace200-fdf1-11e8-8e59-13b7a42a5646.png)
