### PR TITLE
Only show API key info for providers that require an API key.

### DIFF
--- a/src/components/CatalogSearchCriteria.tsx
+++ b/src/components/CatalogSearchCriteria.tsx
@@ -94,7 +94,7 @@ export class CatalogSearchCriteria extends React.Component<Props> {
               onChange={this.handleApiKeyChange}
             />
           </label>}
-        {!(hideApiKeyInput || this.props.catalog.apiKey) && (
+        {(!hideApiKeyInput && !this.props.catalog.apiKey) && (
           <div className={styles.apiKeyInfo}>
             <span>An API key is required. To obtain an API key, please fill out <a href={`/${this.apiKeyFormFileName}`} onClick={this.downloadApiKeyDocument}>this document</a> and follow its instructions.</span>
           </div>

--- a/src/components/CatalogSearchCriteria.tsx
+++ b/src/components/CatalogSearchCriteria.tsx
@@ -53,6 +53,9 @@ export class CatalogSearchCriteria extends React.Component<Props> {
   }
 
   render() {
+    const selectedSceneTileProvider = SCENE_TILE_PROVIDERS.find(p => p.prefix === this.props.catalog.searchCriteria.source)
+    const hideApiKeyInput = (selectedSceneTileProvider) ? selectedSceneTileProvider.hideApiKeyInput : false
+
     return (
       <div className={styles.root}>
         <div className={styles.minimap}>
@@ -78,7 +81,7 @@ export class CatalogSearchCriteria extends React.Component<Props> {
               ))}
           </select>
         </label>
-        {(SCENE_TILE_PROVIDERS.find(p => p.prefix === this.props.catalog.searchCriteria.source) || { hideApiKeyInput: false }).hideApiKeyInput ? '' :
+        {hideApiKeyInput ? '' :
           <label className={styles.apiKey}>
             <span>API Key</span>
             <input
@@ -91,7 +94,7 @@ export class CatalogSearchCriteria extends React.Component<Props> {
               onChange={this.handleApiKeyChange}
             />
           </label>}
-        {!this.props.catalog.apiKey && (
+        {!(hideApiKeyInput || this.props.catalog.apiKey) && (
           <div className={styles.apiKeyInfo}>
             <span>An API key is required. To obtain an API key, please fill out <a href={`/${this.apiKeyFormFileName}`} onClick={this.downloadApiKeyDocument}>this document</a> and follow its instructions.</span>
           </div>


### PR DESCRIPTION
To reproduce this you have to first select a source that requires an API key and clear your current key. Then switch to Landsat8 and you should now see the info appear erroneously.

![selection_097](https://user-images.githubusercontent.com/3220897/50499141-1168cc00-09fc-11e9-9b11-149db67d895c.png)
