### PR TITLE
Add proper type checking for Redux action payloads.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4159,7 +4159,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4180,12 +4181,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4200,17 +4203,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4327,7 +4333,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4339,6 +4346,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4353,6 +4361,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4360,12 +4369,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4384,6 +4395,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4464,7 +4476,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4476,6 +4489,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4561,7 +4575,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4597,6 +4612,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4616,6 +4632,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4659,12 +4676,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/actions/algorithmsActions.ts
+++ b/src/actions/algorithmsActions.ts
@@ -76,7 +76,7 @@ export namespace AlgorithmsActions {
     static type = 'ALGORITHMS_FETCH_SUCCESS'
     type = FetchSuccess.type
     constructor(public payload: {
-      records: typeof algorithmsInitialState.records
+      records: AlgorithmsState['records']
     }) {}
   }
 
@@ -84,7 +84,7 @@ export namespace AlgorithmsActions {
     static type = 'ALGORITHMS_FETCH_ERROR'
     type = FetchError.type
     constructor(public payload: {
-      error: typeof algorithmsInitialState.fetchError
+      error: AlgorithmsState['fetchError']
     }) {}
   }
 
@@ -97,7 +97,7 @@ export namespace AlgorithmsActions {
     static type = 'ALGORITHMS_DESERIALIZED'
     type = Deserialized.type
     constructor(public payload: {
-      records: typeof algorithmsInitialState.records
+      records: AlgorithmsState['records']
     }) {}
   }
 }

--- a/src/actions/algorithmsActions.ts
+++ b/src/actions/algorithmsActions.ts
@@ -14,21 +14,95 @@
  * limitations under the License.
  **/
 
-import {Dispatch} from 'redux'
+import {Action, Dispatch} from 'redux'
 import {ALGORITHM_ENDPOINT} from '../config'
 import {getClient} from '../api/session'
 import {AppState} from '../store'
 import {algorithmsInitialState, AlgorithmsState} from '../reducers/algorithmsReducer'
 
-export const algorithmsTypes: ActionTypes = {
-  ALGORITHMS_FETCHING: 'ALGORITHMS_FETCHING',
-  ALGORITHMS_FETCH_SUCCESS: 'ALGORITHMS_FETCH_SUCCESS',
-  ALGORITHMS_FETCH_ERROR: 'ALGORITHMS_FETCH_ERROR',
-  ALGORITHMS_SERIALIZED: 'ALGORITHMS_SERIALIZED',
-  ALGORITHMS_DESERIALIZED: 'ALGORITHMS_DESERIALIZED',
+export namespace Algorithms {
+  export function fetch() {
+    return async (dispatch: Dispatch<AlgorithmsState>) => {
+      dispatch({...new AlgorithmsActions.Fetching()})
+
+      try {
+        const response = await getClient().get(ALGORITHM_ENDPOINT) as FetchResponse
+        dispatch({...new AlgorithmsActions.FetchSuccess({
+          records: response.data.algorithms.map(record => ({
+            description: record.description,
+            id: record.service_id,
+            maxCloudCover: record.max_cloud_cover,
+            name: record.name,
+            type: record.interface,
+          })),
+        })})
+      } catch (error) {
+        dispatch({...new AlgorithmsActions.FetchError({ error })})
+      }
+    }
+  }
+
+  export function serialize() {
+    return (dispatch: Dispatch<AlgorithmsState>, getState: () => AppState) => {
+      const state = getState()
+
+      sessionStorage.setItem('algorithms_records', JSON.stringify(state.algorithms.records))
+
+      dispatch({...new AlgorithmsActions.Serialized()})
+    }
+  }
+
+  export function deserialize() {
+    let records: beachfront.Algorithm[] | null = null
+    try {
+      records = JSON.parse(sessionStorage.getItem('algorithms_records') || 'null')
+    } catch (error) {
+      console.warn('Failed to deserialize "algorithms_records"')
+    }
+
+    return {...new AlgorithmsActions.Deserialized({
+      records: records || algorithmsInitialState.records,
+    })}
+  }
 }
 
-type FetchResponse = {
+export namespace AlgorithmsActions {
+  export class Fetching implements Action {
+    static type = 'ALGORITHMS_FETCHING'
+    type = Fetching.type
+  }
+
+  export class FetchSuccess implements Action {
+    static type = 'ALGORITHMS_FETCH_SUCCESS'
+    type = FetchSuccess.type
+    constructor(public payload: {
+      records: typeof algorithmsInitialState.records
+    }) {}
+  }
+
+  export class FetchError implements Action {
+    static type = 'ALGORITHMS_FETCH_ERROR'
+    type = FetchError.type
+    constructor(public payload: {
+      error: typeof algorithmsInitialState.fetchError
+    }) {}
+  }
+
+  export class Serialized implements Action {
+    static type = 'ALGORITHMS_SERIALIZED'
+    type = Serialized.type
+  }
+
+  export class Deserialized implements Action {
+    static type = 'ALGORITHMS_DESERIALIZED'
+    type = Deserialized.type
+    constructor(public payload: {
+      records: typeof algorithmsInitialState.records
+    }) {}
+  }
+}
+
+interface FetchResponse {
   data: {
     algorithms: Array<{
       description: string
@@ -38,56 +112,4 @@ type FetchResponse = {
       interface: string
     }>
   }
-}
-
-export const algorithmsActions = {
-  fetch() {
-    return async (dispatch: Dispatch<AlgorithmsState>) => {
-      dispatch({ type: algorithmsTypes.ALGORITHMS_FETCHING })
-
-      try {
-        const response = await getClient().get(ALGORITHM_ENDPOINT) as FetchResponse
-        dispatch({
-          type: algorithmsTypes.ALGORITHMS_FETCH_SUCCESS,
-          records: response.data.algorithms.map(record => ({
-            description: record.description,
-            id: record.service_id,
-            maxCloudCover: record.max_cloud_cover,
-            name: record.name,
-            type: record.interface,
-          })),
-        })
-      } catch (error) {
-        dispatch({
-          type: algorithmsTypes.ALGORITHMS_FETCH_ERROR,
-          error,
-        })
-      }
-    }
-  },
-
-  serialize() {
-    return (dispatch: Dispatch<AlgorithmsState>, getState: () => AppState) => {
-      const state = getState()
-
-      sessionStorage.setItem('algorithms_records', JSON.stringify(state.algorithms.records))
-
-      dispatch({ type: algorithmsTypes.ALGORITHMS_SERIALIZED })
-    }
-  },
-
-  deserialize() {
-    const deserialized: any = {}
-
-    try {
-      deserialized.records = JSON.parse(sessionStorage.getItem('algorithms_records') || 'null') || algorithmsInitialState.records
-    } catch (error) {
-      console.warn('Failed to deserialize "algorithms_records"')
-    }
-
-    return {
-      type: algorithmsTypes.ALGORITHMS_DESERIALIZED,
-      deserialized,
-    }
-  },
 }

--- a/src/actions/apiStatusActions.ts
+++ b/src/actions/apiStatusActions.ts
@@ -14,20 +14,102 @@
  * limitations under the License.
  **/
 
-import {Dispatch} from 'redux'
+import {Action, Dispatch} from 'redux'
 import {getClient} from '../api/session'
 import {AppState} from '../store'
 import {apiStatusInitialState, ApiStatusState} from '../reducers/apiStatusReducer'
 
-export const apiStatusTypes: ActionTypes = {
-  API_STATUS_FETCHING: 'API_STATUS_FETCHING',
-  API_STATUS_FETCH_SUCCESS: 'API_STATUS_FETCH_SUCCESS',
-  API_STATUS_FETCH_ERROR: 'API_STATUS_FETCH_ERROR',
-  API_STATUS_SERIALIZED: 'API_STATUS_SERIALIZED',
-  API_STATUS_DESERIALIZED: 'API_STATUS_DESERIALIZED',
+export namespace ApiStatus {
+  export function fetch() {
+    return async (dispatch: Dispatch<ApiStatusState>) => {
+      dispatch({...new ApiStatusActions.Fetching()})
+
+      try {
+        const response = await getClient().get('/') as FetchResponse
+        dispatch({...new ApiStatusActions.FetchSuccess({
+          geoserver: {
+            wmsUrl: response.data.geoserver + '/wms',
+          },
+          enabledPlatforms: response.data['enabled-platforms'],
+        })})
+      } catch (error) {
+        dispatch({...new ApiStatusActions.FetchError({ error })})
+      }
+    }
+  }
+
+  export function serialize() {
+    return (dispatch: Dispatch<ApiStatusState>, getState: () => AppState) => {
+      const state = getState()
+
+      sessionStorage.setItem('geoserver', JSON.stringify(state.apiStatus.geoserver))
+      sessionStorage.setItem('enabled_platforms_records', JSON.stringify(state.apiStatus.enabledPlatforms))
+
+      dispatch({...new ApiStatusActions.Serialized()})
+    }
+  }
+
+  export function deserialize() {
+    let geoserver: typeof apiStatusInitialState.geoserver | null = null
+    try {
+      geoserver = JSON.parse(sessionStorage.getItem('geoserver') || 'null')
+    } catch (error) {
+      console.warn('Failed to deserialize "geoserver"')
+    }
+
+    let enabledPlatforms: typeof apiStatusInitialState.enabledPlatforms | null = null
+    try {
+      enabledPlatforms = JSON.parse(sessionStorage.getItem('enabled_platforms_records') || 'null')
+    } catch (error) {
+      console.warn('Failed to deserialize "enabled_platforms_records"')
+    }
+
+    return {...new ApiStatusActions.Deserialized({
+      geoserver: geoserver || apiStatusInitialState.geoserver,
+      enabledPlatforms: enabledPlatforms || apiStatusInitialState.enabledPlatforms,
+    })}
+  }
 }
 
-type FetchResponse = {
+export namespace ApiStatusActions {
+  export class Fetching implements Action {
+    static type = 'API_STATUS_FETCHING'
+    type = Fetching.type
+  }
+
+  export class FetchSuccess implements Action {
+    static type = 'API_STATUS_FETCH_SUCCESS'
+    type = FetchSuccess.type
+    constructor(public payload: {
+      geoserver: typeof apiStatusInitialState.geoserver
+      enabledPlatforms: typeof apiStatusInitialState.enabledPlatforms
+    }) {}
+  }
+
+  export class FetchError implements Action {
+    static type = 'API_STATUS_FETCH_ERROR'
+    type = FetchError.type
+    constructor(public payload: {
+      error: typeof apiStatusInitialState.fetchError
+    }) {}
+  }
+
+  export class Serialized implements Action {
+    static type = 'API_STATUS_SERIALIZED'
+    type = Serialized.type
+  }
+
+  export class Deserialized implements Action {
+    static type = 'API_STATUS_DESERIALIZED'
+    type = Deserialized.type
+    constructor(public payload: {
+      geoserver: typeof apiStatusInitialState.geoserver
+      enabledPlatforms: typeof apiStatusInitialState.enabledPlatforms
+    }) {}
+  }
+}
+
+interface FetchResponse {
   data: {
     geoserver: string
     'geoserver-upstream': string
@@ -35,60 +117,4 @@ type FetchResponse = {
     'outstanding-jobs': number
     uptime: number
   }
-}
-
-export const apiStatusActions = {
-  fetch() {
-    return async (dispatch: Dispatch<ApiStatusState>) => {
-      dispatch({ type: apiStatusTypes.API_STATUS_FETCHING })
-
-      try {
-        const response = await getClient().get('/') as FetchResponse
-        dispatch({
-          type: apiStatusTypes.API_STATUS_FETCH_SUCCESS,
-          geoserver: {
-            wmsUrl: response.data.geoserver + '/wms',
-          },
-          enabledPlatforms: response.data['enabled-platforms'],
-        })
-      } catch (error) {
-        dispatch({
-          type: apiStatusTypes.API_STATUS_FETCH_ERROR,
-          error,
-        })
-      }
-    }
-  },
-
-  serialize() {
-    return (dispatch: Dispatch<ApiStatusState>, getState: () => AppState) => {
-      const state = getState()
-
-      sessionStorage.setItem('geoserver', JSON.stringify(state.apiStatus.geoserver))
-      sessionStorage.setItem('enabled_platforms_records', JSON.stringify(state.apiStatus.enabledPlatforms))
-
-      dispatch({ type: apiStatusTypes.API_STATUS_SERIALIZED })
-    }
-  },
-
-  deserialize() {
-    const deserialized: any = {}
-
-    try {
-      deserialized.geoserver = JSON.parse(sessionStorage.getItem('geoserver') || 'null') || apiStatusInitialState.geoserver
-    } catch (error) {
-      console.warn('Failed to deserialize "geoserver"')
-    }
-
-    try {
-      deserialized.enabledPlatforms = JSON.parse(sessionStorage.getItem('enabled_platforms_records') || 'null') || apiStatusInitialState.enabledPlatforms
-    } catch (error) {
-      console.warn('Failed to deserialize "enabled_platforms_records"')
-    }
-
-    return {
-      type: apiStatusTypes.API_STATUS_DESERIALIZED,
-      deserialized,
-    }
-  },
 }

--- a/src/actions/apiStatusActions.ts
+++ b/src/actions/apiStatusActions.ts
@@ -81,8 +81,8 @@ export namespace ApiStatusActions {
     static type = 'API_STATUS_FETCH_SUCCESS'
     type = FetchSuccess.type
     constructor(public payload: {
-      geoserver: typeof apiStatusInitialState.geoserver
-      enabledPlatforms: typeof apiStatusInitialState.enabledPlatforms
+      geoserver: ApiStatusState['geoserver']
+      enabledPlatforms: ApiStatusState['enabledPlatforms']
     }) {}
   }
 
@@ -90,7 +90,7 @@ export namespace ApiStatusActions {
     static type = 'API_STATUS_FETCH_ERROR'
     type = FetchError.type
     constructor(public payload: {
-      error: typeof apiStatusInitialState.fetchError
+      error: ApiStatusState['fetchError']
     }) {}
   }
 
@@ -103,8 +103,8 @@ export namespace ApiStatusActions {
     static type = 'API_STATUS_DESERIALIZED'
     type = Deserialized.type
     constructor(public payload: {
-      geoserver: typeof apiStatusInitialState.geoserver
-      enabledPlatforms: typeof apiStatusInitialState.enabledPlatforms
+      geoserver: ApiStatusState['geoserver']
+      enabledPlatforms: ApiStatusState['enabledPlatforms']
     }) {}
   }
 }

--- a/src/actions/catalogActions.ts
+++ b/src/actions/catalogActions.ts
@@ -14,67 +14,28 @@
  * limitations under the License.
  **/
 
-import {Dispatch} from 'redux'
+import {Action, Dispatch} from 'redux'
+import {GeoJSON} from 'geojson'
 import {AppState} from '../store'
 import {IMAGERY_ENDPOINT, SCENE_TILE_PROVIDERS} from '../config'
 import {getClient} from '../api/session'
 import {wrap} from '../utils/math'
 import {catalogInitialState, CatalogState} from '../reducers/catalogReducer'
 
-export const catalogTypes: ActionTypes = {
-  CATALOG_INITIALIZING: 'CATALOG_INITIALIZING',
-  CATALOG_INITIALIZE_SUCCESS: 'CATALOG_INITIALIZE_SUCCESS',
-  CATALOG_INITIALIZE_ERROR: 'CATALOG_INITIALIZE_ERROR',
-  CATALOG_API_KEY_UPDATED: 'CATALOG_API_KEY_UPDATED',
-  CATALOG_SEARCH_CRITERIA_UPDATED: 'CATALOG_SEARCH_CRITERIA_UPDATED',
-  CATALOG_SEARCH_CRITERIA_RESET: 'CATALOG_SEARCH_CRITERIA_RESET',
-  CATALOG_SEARCHING: 'CATALOG_SEARCHING',
-  CATALOG_SEARCH_SUCCESS: 'CATALOG_SEARCH_SUCCESS',
-  CATALOG_SEARCH_ERROR: 'CATALOG_SEARCH_ERROR',
-  CATALOG_SERIALIZED: 'CATALOG_SERIALIZED',
-  CATALOG_DESERIALIZED: 'CATALOG_DESERIALIZED',
-}
-
-export interface CatalogSearchArgs {
-  startIndex: number
-  count: number
-}
-
-export interface CatalogUpdateSearchCriteriaArgs {
-  cloudCover?: number
-  dateFrom?: string
-  dateTo?: string
-  source?: string
-}
-
-type SearchResponse = {
-  data: {
-    features: Array<{
-      id: string
-    }>
+export namespace Catalog {
+  export function setApiKey(apiKey: string) {
+    return {...new CatalogActions.ApiKeyUpdated({ apiKey })}
   }
-}
 
-export const catalogActions = {
-  setApiKey(apiKey: string) {
-    return {
-      type: catalogTypes.CATALOG_API_KEY_UPDATED,
-      apiKey,
-    }
-  },
+  export function updateSearchCriteria(searchCriteria: CatalogUpdateSearchCriteriaArgs) {
+    return {...new CatalogActions.SearchCriteriaUpdated({ searchCriteria })}
+  }
 
-  updateSearchCriteria(searchCriteria: CatalogUpdateSearchCriteriaArgs) {
-    return {
-      type: catalogTypes.CATALOG_SEARCH_CRITERIA_UPDATED,
-      searchCriteria,
-    }
-  },
+  export function resetSearchCriteria() {
+    return {...new CatalogActions.SearchCriteriaReset()}
+  }
 
-  resetSearchCriteria() {
-    return { type: catalogTypes.CATALOG_SEARCH_CRITERIA_RESET }
-  },
-
-  search(args: CatalogSearchArgs = {startIndex: 0, count: 100}) {
+  export function search(args: CatalogSearchArgs = { startIndex: 0, count: 100 }) {
     return async (dispatch: Dispatch<CatalogState>, getState: () => AppState) => {
       const state = getState()
 
@@ -83,7 +44,7 @@ export const catalogActions = {
         return
       }
 
-      dispatch({ type: catalogTypes.CATALOG_SEARCHING })
+      dispatch({...new CatalogActions.Searching()})
 
       console.warn('(catalog:search): Discarding parameters `count` (%s) and `startIndex` (%s)', args.count, args.startIndex)
 
@@ -95,10 +56,9 @@ export const catalogActions = {
 
       let sceneTileProvider = SCENE_TILE_PROVIDERS.find(p => p.prefix === state.catalog.searchCriteria.source)
       if (!sceneTileProvider) {
-        dispatch({
-          type: catalogTypes.CATALOG_SEARCH_ERROR,
+        dispatch({...new CatalogActions.SearchError({
           error: new Error(`Unknown data source prefix: '${state.catalog.searchCriteria.source}'`),
-        })
+        })})
         return
       }
 
@@ -120,25 +80,21 @@ export const catalogActions = {
           f.id = state.catalog.searchCriteria.source + ':' + f.id
         })
 
-        dispatch({
-          type: catalogTypes.CATALOG_SEARCH_SUCCESS,
+        dispatch({...new CatalogActions.SearchSuccess({
           searchResults: {
             images: response.data,
             count: response.data.features.length,
             startIndex: 0,
             totalCount: response.data.features.length,
           },
-        })
+        })})
       } catch (error) {
-        dispatch({
-          type: catalogTypes.CATALOG_SEARCH_ERROR,
-          error,
-        })
+        dispatch({...new CatalogActions.SearchError({ error })})
       }
     }
-  },
+  }
 
-  serialize() {
+  export function serialize() {
     return (dispatch: Dispatch<CatalogState>, getState: () => AppState) => {
       const state = getState()
 
@@ -146,30 +102,106 @@ export const catalogActions = {
       sessionStorage.setItem('searchResults', JSON.stringify(state.catalog.searchResults))
       localStorage.setItem('catalog_apiKey', state.catalog.apiKey)  // HACK
 
-      dispatch({ type: catalogTypes.CATALOG_SERIALIZED })
+      dispatch({...new CatalogActions.Serialized()})
     }
-  },
+  }
 
-  deserialize() {
-    const deserialized: any = {}
-
+  export function deserialize() {
+    let searchCriteria: typeof catalogInitialState.searchCriteria | null = null
     try {
-      deserialized.searchCriteria = JSON.parse(sessionStorage.getItem('searchCriteria') || 'null') || catalogInitialState.searchCriteria
+      searchCriteria = JSON.parse(sessionStorage.getItem('searchCriteria') || 'null')
     } catch (error) {
       console.warn('Failed to deserialize "searchCriteria"')
     }
 
+    let searchResults: typeof catalogInitialState.searchResults | null = null
     try {
-      deserialized.searchResults = JSON.parse(sessionStorage.getItem('searchResults') || 'null')
+      searchResults = JSON.parse(sessionStorage.getItem('searchResults') || 'null')
     } catch (error) {
       console.warn('Failed to deserialize "searchResults"')
     }
 
-    deserialized.apiKey = localStorage.getItem('catalog_apiKey') || catalogInitialState.apiKey
+    const apiKey: string | null = localStorage.getItem('catalog_apiKey')
 
-    return {
-      type: catalogTypes.CATALOG_DESERIALIZED,
-      deserialized,
-    }
-  },
+    return {...new CatalogActions.Deserialized({
+      searchCriteria: searchCriteria || catalogInitialState.searchCriteria,
+      searchResults,
+      apiKey: apiKey || catalogInitialState.apiKey,
+    })}
+  }
+}
+
+export namespace CatalogActions {
+  export class ApiKeyUpdated implements Action {
+    static type = 'CATALOG_API_KEY_UPDATED'
+    type = ApiKeyUpdated.type
+    constructor(public payload: {
+      apiKey: typeof catalogInitialState.apiKey
+    }) {}
+  }
+
+  export class SearchCriteriaUpdated implements Action {
+    static type = 'CATALOG_SEARCH_CRITERIA_UPDATED'
+    type = SearchCriteriaUpdated.type
+    constructor(public payload: {
+      searchCriteria: CatalogUpdateSearchCriteriaArgs
+    }) {}
+  }
+
+  export class SearchCriteriaReset implements Action {
+    static type = 'CATALOG_SEARCH_CRITERIA_RESET'
+    type = SearchCriteriaReset.type
+  }
+
+  export class Searching implements Action {
+    static type = 'CATALOG_SEARCHING'
+    type = Searching.type
+  }
+
+  export class SearchSuccess implements Action {
+    static type = 'CATALOG_SEARCH_SUCCESS'
+    type = SearchSuccess.type
+    constructor(public payload: {
+      searchResults: NonNullable<typeof catalogInitialState.searchResults>
+    }) {}
+  }
+
+  export class SearchError implements Action {
+    static type = 'CATALOG_SEARCH_ERROR'
+    type = SearchError.type
+    constructor(public payload: {
+      error: typeof catalogInitialState.searchError
+    }) {}
+  }
+
+  export class Serialized implements Action {
+    static type = 'CATALOG_SERIALIZED'
+    type = Serialized.type
+  }
+
+  export class Deserialized implements Action {
+    static type = 'CATALOG_DESERIALIZED'
+    type = Deserialized.type
+    constructor(public payload: {
+      searchCriteria: typeof catalogInitialState.searchCriteria
+      searchResults: typeof catalogInitialState.searchResults
+      apiKey: typeof catalogInitialState.apiKey
+    }) {}
+  }
+}
+
+export interface CatalogSearchArgs {
+  startIndex: number
+  count: number
+}
+
+export interface CatalogUpdateSearchCriteriaArgs {
+  cloudCover?: number
+  dateFrom?: string
+  dateTo?: string
+  source?: string
+}
+
+interface SearchResponse {
+  data: GeoJSON.FeatureCollection<any>
 }

--- a/src/actions/catalogActions.ts
+++ b/src/actions/catalogActions.ts
@@ -136,7 +136,7 @@ export namespace CatalogActions {
     static type = 'CATALOG_API_KEY_UPDATED'
     type = ApiKeyUpdated.type
     constructor(public payload: {
-      apiKey: typeof catalogInitialState.apiKey
+      apiKey: CatalogState['apiKey']
     }) {}
   }
 
@@ -162,7 +162,7 @@ export namespace CatalogActions {
     static type = 'CATALOG_SEARCH_SUCCESS'
     type = SearchSuccess.type
     constructor(public payload: {
-      searchResults: NonNullable<typeof catalogInitialState.searchResults>
+      searchResults: NonNullable<CatalogState['searchResults']>
     }) {}
   }
 
@@ -170,7 +170,7 @@ export namespace CatalogActions {
     static type = 'CATALOG_SEARCH_ERROR'
     type = SearchError.type
     constructor(public payload: {
-      error: typeof catalogInitialState.searchError
+      error: CatalogState['searchError']
     }) {}
   }
 
@@ -183,9 +183,9 @@ export namespace CatalogActions {
     static type = 'CATALOG_DESERIALIZED'
     type = Deserialized.type
     constructor(public payload: {
-      searchCriteria: typeof catalogInitialState.searchCriteria
-      searchResults: typeof catalogInitialState.searchResults
-      apiKey: typeof catalogInitialState.apiKey
+      searchCriteria: CatalogState['searchCriteria']
+      searchResults: CatalogState['searchResults']
+      apiKey: CatalogState['apiKey']
     }) {}
   }
 }

--- a/src/actions/jobsActions.ts
+++ b/src/actions/jobsActions.ts
@@ -17,7 +17,7 @@
 import {Action, Dispatch} from 'redux'
 import {getClient} from '../api/session'
 import {JOB_ENDPOINT} from '../config'
-import {jobsInitialState, JobsState} from '../reducers/jobsReducer'
+import {JobsState} from '../reducers/jobsReducer'
 
 export namespace Jobs {
   export function fetch() {
@@ -99,7 +99,7 @@ export namespace JobsActions {
     static type = 'JOBS_FETCH_SUCCESS'
     type = FetchSuccess.type
     constructor(public payload: {
-      records: typeof jobsInitialState.records,
+      records: JobsState['records']
     }) {}
   }
 
@@ -107,7 +107,7 @@ export namespace JobsActions {
     static type = 'JOBS_FETCH_ERROR'
     type = FetchError.type
     constructor(public payload: {
-      error: typeof jobsInitialState.fetchError,
+      error: JobsState['fetchError']
     }) {}
   }
 
@@ -120,7 +120,7 @@ export namespace JobsActions {
     static type = 'JOBS_FETCH_ONE_SUCCESS'
     type = FetchOneSuccess.type
     constructor(public payload: {
-      record: typeof jobsInitialState.records[0],
+      record: JobsState['records'][0]
     }) {}
   }
 
@@ -128,7 +128,7 @@ export namespace JobsActions {
     static type = 'JOBS_FETCH_ONE_ERROR'
     type = FetchOneError.type
     constructor(public payload: {
-      error: typeof jobsInitialState.fetchOneError,
+      error: JobsState['fetchOneError']
     }) {}
   }
 
@@ -141,7 +141,7 @@ export namespace JobsActions {
     static type = 'JOBS_CREATE_JOB_SUCCESS'
     type = CreateJobSuccess.type
     constructor(public payload: {
-      createdJob: NonNullable<typeof jobsInitialState.createdJob>
+      createdJob: NonNullable<JobsState['createdJob']>
     }) {}
   }
 
@@ -149,7 +149,7 @@ export namespace JobsActions {
     static type = 'JOBS_CREATE_JOB_ERROR'
     type = CreateJobError.type
     constructor(public payload: {
-      error: typeof jobsInitialState.createJobError
+      error: JobsState['createJobError']
     }) {}
   }
 
@@ -162,7 +162,7 @@ export namespace JobsActions {
     static type = 'JOBS_DELETING_JOB'
     type = DeletingJob.type
     constructor(public payload: {
-      deletedJob: NonNullable<typeof jobsInitialState.deletedJob>
+      deletedJob: NonNullable<JobsState['deletedJob']>
     }) {}
   }
 
@@ -175,7 +175,7 @@ export namespace JobsActions {
     static type = 'JOBS_DELETE_JOB_ERROR'
     type = DeleteJobError.type
     constructor(public payload: {
-      error: typeof jobsInitialState.deleteJobError
+      error: JobsState['deleteJobError']
     }) {}
   }
 }

--- a/src/actions/jobsActions.ts
+++ b/src/actions/jobsActions.ts
@@ -14,25 +14,170 @@
  * limitations under the License.
  **/
 
-import {Dispatch} from 'redux'
+import {Action, Dispatch} from 'redux'
 import {getClient} from '../api/session'
 import {JOB_ENDPOINT} from '../config'
-import {JobsState} from '../reducers/jobsReducer'
+import {jobsInitialState, JobsState} from '../reducers/jobsReducer'
 
-export const jobsTypes: ActionTypes = {
-  JOBS_FETCHING: 'JOBS_FETCHING',
-  JOBS_FETCH_SUCCESS: 'JOBS_FETCH_SUCCESS',
-  JOBS_FETCH_ERROR: 'JOBS_FETCH_ERROR',
-  JOBS_FETCHING_ONE: 'JOBS_FETCHING_ONE',
-  JOBS_FETCH_ONE_SUCCESS: 'JOBS_FETCH_ONE_SUCCESS',
-  JOBS_FETCH_ONE_ERROR: 'JOBS_FETCH_ONE_ERROR',
-  JOBS_CREATING_JOB: 'JOBS_CREATING_JOB',
-  JOBS_CREATE_JOB_SUCCESS: 'JOBS_CREATE_JOB_SUCCESS',
-  JOBS_CREATE_JOB_ERROR: 'JOBS_CREATE_JOB_ERROR',
-  JOBS_CREATE_JOB_ERROR_DISMISSED: 'JOBS_CREATE_JOB_ERROR_DISMISSED',
-  JOBS_DELETING_JOB: 'JOBS_DELETING_JOB',
-  JOBS_DELETE_JOB_SUCCESS: 'JOBS_DELETE_JOB_SUCCESS',
-  JOBS_DELETE_JOB_ERROR: 'JOBS_DELETE_JOB_ERROR',
+export namespace Jobs {
+  export function fetch() {
+    return async (dispatch: Dispatch<JobsState>) => {
+      dispatch({...new JobsActions.Fetching()})
+
+      try {
+        const response = await getClient().get(JOB_ENDPOINT) as FetchResponse
+        dispatch({...new JobsActions.FetchSuccess({
+          records: response.data.jobs.features,
+        })})
+      } catch (error) {
+        dispatch({...new JobsActions.FetchError({ error })})
+      }
+    }
+  }
+
+  export function fetchOne(jobId: string) {
+    return async (dispatch: Dispatch<JobsState>) => {
+      dispatch({...new JobsActions.FetchingOne()})
+
+      try {
+        const response = await getClient().get(`${JOB_ENDPOINT}/${jobId}`) as FetchOneResponse
+        dispatch({...new JobsActions.FetchOneSuccess({
+          record: response.data.job,
+        })})
+      } catch (error) {
+        dispatch({...new JobsActions.FetchOneError({ error })})
+      }
+    }
+  }
+
+  export function createJob(args: JobsCreateJobArgs) {
+    return async (dispatch: Dispatch<JobsState>) => {
+      dispatch({...new JobsActions.CreatingJob()})
+
+      try {
+        const response = await getClient().post(JOB_ENDPOINT, {
+          algorithm_id: args.algorithmId,
+          compute_mask: args.computeMask,
+          name: args.name,
+          planet_api_key: args.catalogApiKey,
+          scene_id: args.sceneId,
+        })
+        dispatch({...new JobsActions.CreateJobSuccess({
+          createdJob: response.data.job,
+        })})
+      } catch (error) {
+        dispatch({...new JobsActions.CreateJobError({ error })})
+      }
+    }
+  }
+
+  export function dismissCreateJobError() {
+    return {...new JobsActions.CreateJobErrorDismissed()}
+  }
+
+  export function deleteJob(job: beachfront.Job) {
+    return async (dispatch: Dispatch<JobsState>) => {
+      dispatch({...new JobsActions.DeletingJob({ deletedJob: job })})
+
+      try {
+        await getClient().delete(`${JOB_ENDPOINT}/${job.id}`)
+        dispatch({...new JobsActions.DeleteJobSuccess()})
+      } catch (error) {
+        dispatch({...new JobsActions.DeleteJobError({ error })})
+      }
+    }
+  }
+}
+
+export namespace JobsActions {
+  export class Fetching implements Action {
+    static type = 'JOBS_FETCHING'
+    type = Fetching.type
+  }
+
+  export class FetchSuccess implements Action {
+    static type = 'JOBS_FETCH_SUCCESS'
+    type = FetchSuccess.type
+    constructor(public payload: {
+      records: typeof jobsInitialState.records,
+    }) {}
+  }
+
+  export class FetchError implements Action {
+    static type = 'JOBS_FETCH_ERROR'
+    type = FetchError.type
+    constructor(public payload: {
+      error: typeof jobsInitialState.fetchError,
+    }) {}
+  }
+
+  export class FetchingOne implements Action {
+    static type = 'JOBS_FETCHING_ONE'
+    type = FetchingOne.type
+  }
+
+  export class FetchOneSuccess implements Action {
+    static type = 'JOBS_FETCH_ONE_SUCCESS'
+    type = FetchOneSuccess.type
+    constructor(public payload: {
+      record: typeof jobsInitialState.records[0],
+    }) {}
+  }
+
+  export class FetchOneError implements Action {
+    static type = 'JOBS_FETCH_ONE_ERROR'
+    type = FetchOneError.type
+    constructor(public payload: {
+      error: typeof jobsInitialState.fetchOneError,
+    }) {}
+  }
+
+  export class CreatingJob implements Action {
+    static type = 'JOBS_CREATING_JOB'
+    type = CreatingJob.type
+  }
+
+  export class CreateJobSuccess implements Action {
+    static type = 'JOBS_CREATE_JOB_SUCCESS'
+    type = CreateJobSuccess.type
+    constructor(public payload: {
+      createdJob: NonNullable<typeof jobsInitialState.createdJob>
+    }) {}
+  }
+
+  export class CreateJobError implements Action {
+    static type = 'JOBS_CREATE_JOB_ERROR'
+    type = CreateJobError.type
+    constructor(public payload: {
+      error: typeof jobsInitialState.createJobError
+    }) {}
+  }
+
+  export class CreateJobErrorDismissed implements Action {
+    static type = 'JOBS_CREATE_JOB_ERROR_DISMISSED'
+    type = CreateJobErrorDismissed.type
+  }
+
+  export class DeletingJob implements Action {
+    static type = 'JOBS_DELETING_JOB'
+    type = DeletingJob.type
+    constructor(public payload: {
+      deletedJob: NonNullable<typeof jobsInitialState.deletedJob>
+    }) {}
+  }
+
+  export class DeleteJobSuccess implements Action {
+    static type = 'JOBS_DELETE_JOB_SUCCESS'
+    type = DeleteJobSuccess.type
+  }
+
+  export class DeleteJobError implements Action {
+    static type = 'JOBS_DELETE_JOB_ERROR'
+    type = DeleteJobError.type
+    constructor(public payload: {
+      error: typeof jobsInitialState.deleteJobError
+    }) {}
+  }
 }
 
 export interface JobsCreateJobArgs {
@@ -43,90 +188,16 @@ export interface JobsCreateJobArgs {
   sceneId: string
 }
 
-export const jobsActions = {
-  fetch() {
-    return async (dispatch: Dispatch<JobsState>) => {
-      dispatch({ type: jobsTypes.JOBS_FETCHING })
-
-      try {
-        const response = await getClient().get(JOB_ENDPOINT)
-        dispatch({
-          type: jobsTypes.JOBS_FETCH_SUCCESS,
-          records: response.data.jobs.features,
-        })
-      } catch (error) {
-        dispatch({
-          type: jobsTypes.JOBS_FETCH_ERROR,
-          error,
-        })
-      }
-    }
+interface FetchResponse {
+  data: {
+    jobs: {
+      features: beachfront.Job[]
+    },
   },
+}
 
-  fetchOne(jobId: string) {
-    return async (dispatch: Dispatch<JobsState>) => {
-      dispatch({ type: jobsTypes.JOBS_FETCHING_ONE })
-
-      try {
-        const response = await getClient().get(`${JOB_ENDPOINT}/${jobId}`)
-        dispatch({
-          type: jobsTypes.JOBS_FETCH_ONE_SUCCESS,
-          record: response.data.job,
-        })
-      } catch (error) {
-        dispatch({
-          type: jobsTypes.JOBS_FETCH_ONE_ERROR,
-          error,
-        })
-      }
-    }
-  },
-
-  createJob(args: JobsCreateJobArgs) {
-    return async (dispatch: Dispatch<JobsState>) => {
-      dispatch({ type: jobsTypes.JOBS_CREATING_JOB })
-
-      try {
-        const response = await getClient().post(JOB_ENDPOINT, {
-          algorithm_id: args.algorithmId,
-          compute_mask: args.computeMask,
-          name: args.name,
-          planet_api_key: args.catalogApiKey,
-          scene_id: args.sceneId,
-        })
-        dispatch({
-          type: jobsTypes.JOBS_CREATE_JOB_SUCCESS,
-          createdJob: response.data.job,
-        })
-      } catch (error) {
-        dispatch({
-          type: jobsTypes.JOBS_CREATE_JOB_ERROR,
-          error,
-        })
-      }
-    }
-  },
-
-  dismissCreateJobError() {
-    return { type: jobsTypes.JOBS_CREATE_JOB_ERROR_DISMISSED }
-  },
-
-  deleteJob(job: beachfront.Job) {
-    return async (dispatch: Dispatch<JobsState>) => {
-      dispatch({
-        type: jobsTypes.JOBS_DELETING_JOB,
-        deletedJob: job,
-      })
-
-      try {
-        await getClient().delete(`${JOB_ENDPOINT}/${job.id}`)
-        dispatch({ type: jobsTypes.JOBS_DELETE_JOB_SUCCESS })
-      } catch (error) {
-        dispatch({
-          type: jobsTypes.JOBS_DELETE_JOB_ERROR,
-          error,
-        })
-      }
-    }
-  },
+interface FetchOneResponse {
+  data: {
+    job: beachfront.Job
+  }
 }

--- a/src/actions/mapActions.ts
+++ b/src/actions/mapActions.ts
@@ -14,44 +14,23 @@
  * limitations under the License.
  **/
 
+import {GeoJSON} from 'geojson'
 import {MapView, MODE_DRAW_BBOX, MODE_NORMAL, MODE_PRODUCT_LINES, MODE_SELECT_IMAGERY} from '../components/PrimaryMap'
 import {wrap} from '../utils/math'
 import {AppState} from '../store'
 import {Extent, Point} from '../utils/geometries'
-import {Dispatch} from 'redux'
-import {MapCollections, MapState} from '../reducers/mapReducer'
+import {Action, Dispatch} from 'redux'
+import {MapCollections, mapInitialState, MapState} from '../reducers/mapReducer'
 
-export const mapTypes: ActionTypes = {
-  MAP_INITIALIZED: 'MAP_INITIALIZED',
-  MAP_MODE_UPDATED: 'MAP_MODE_UPDATED',
-  MAP_DETECTIONS_UPDATED: 'MAP_DETECTIONS_UPDATED',
-  MAP_FRAMES_UPDATED: 'MAP_FRAMES_UPDATED',
-  MAP_BBOX_UPDATED: 'MAP_BBOX_UPDATED',
-  MAP_BBOX_CLEARED: 'MAP_BBOX_CLEARED',
-  MAP_SELECTED_FEATURE_UPDATED: 'MAP_SELECTED_FEATURE_UPDATED',
-  MAP_HOVERED_FEATURE_UPDATED: 'MAP_HOVERED_FEATURE_UPDATED',
-  MAP_VIEW_UPDATED: 'MAP_VIEW_UPDATED',
-  MAP_PAN_TO_POINT: 'MAP_PAN_TO_POINT',
-  MAP_PAN_TO_EXTENT: 'MAP_PAN_TO_EXTENT',
-  MAP_SERIALIZED: 'MAP_SERIALIZED',
-  MAP_DESERIALIZED: 'MAP_DESERIALIZED',
-}
-
-export interface MapPanToPointArgs {
-  point: Point
-  zoom?: number
-}
-
-export const mapActions = {
-  initialized(map: ol.Map, collections: MapCollections) {
-    return {
-      type: mapTypes.MAP_INITIALIZED,
+export namespace Map {
+  export function initialized(map: ol.Map, collections: MapCollections) {
+    return {...new MapActions.Initialized({
       map,
       collections,
-    }
-  },
+    })}
+  }
 
-  updateMode() {
+  export function updateMode() {
     return (dispatch: Dispatch<MapState>, getState: () => AppState) => {
       const state = getState()
 
@@ -70,25 +49,19 @@ export const mapActions = {
           mode = MODE_NORMAL
       }
 
-      dispatch({
-        type: mapTypes.MAP_MODE_UPDATED,
-        mode,
-      })
+      dispatch({...new MapActions.ModeUpdated({ mode })})
     }
-  },
+  }
 
-  updateBbox(bbox: Extent | null) {
-    return {
-      type: mapTypes.MAP_BBOX_UPDATED,
-      bbox,
-    }
-  },
+  export function updateBbox(bbox: Extent | null) {
+    return {...new MapActions.BboxUpdated({ bbox })}
+  }
 
-  clearBbox() {
-    return { type: mapTypes.MAP_BBOX_CLEARED }
-  },
+  export function clearBbox() {
+    return {...new MapActions.BboxCleared()}
+  }
 
-  updateDetections() {
+  export function updateDetections() {
     return (dispatch: Dispatch<MapState>, getState: () => AppState) => {
       const state = getState()
 
@@ -116,15 +89,12 @@ export const mapActions = {
       }
 
       if (detectionsChanged) {
-        dispatch({
-          type: mapTypes.MAP_DETECTIONS_UPDATED,
-          detections,
-        })
+        dispatch({...new MapActions.DetectionsUpdated({ detections })})
       }
     }
-  },
+  }
 
-  updateFrames() {
+  export function updateFrames() {
     return (dispatch: Dispatch<MapState>, getState: () => AppState) => {
       const state = getState()
 
@@ -152,15 +122,12 @@ export const mapActions = {
       }
 
       if (framesChanged) {
-        dispatch({
-          type: mapTypes.MAP_FRAMES_UPDATED,
-          frames,
-        })
+        dispatch({...new MapActions.FramesUpdated({ frames })})
       }
     }
-  },
+  }
 
-  setSelectedFeature(feature: GeoJSON.Feature<any> | null) {
+  export function setSelectedFeature(feature: GeoJSON.Feature<any> | null) {
     return (dispatch: Dispatch<MapState>, getState: () => AppState) => {
       const state = getState()
 
@@ -168,48 +135,32 @@ export const mapActions = {
         return  // Nothing to do
       }
 
-      dispatch({
-        type: mapTypes.MAP_SELECTED_FEATURE_UPDATED,
+      dispatch({...new MapActions.SelectedFeatureUpdated({
         selectedFeature: feature,
-      })
+      })})
     }
-  },
+  }
 
-  setHoveredFeature(hoveredFeature: beachfront.Job | null) {
-    return {
-      type: mapTypes.MAP_HOVERED_FEATURE_UPDATED,
-      hoveredFeature,
-    }
-  },
+  export function setHoveredFeature(hoveredFeature: beachfront.Job | null) {
+    return {...new MapActions.HoveredFeatureUpdated({ hoveredFeature })}
+  }
 
-  updateView(view: MapView) {
-    return {
-      type: mapTypes.MAP_VIEW_UPDATED,
-      view,
-    }
-  },
+  export function updateView(view: MapView) {
+    return {...new MapActions.ViewUpdated({ view })}
+  }
 
-  panToPoint(args: MapPanToPointArgs) {
-    args = {
-      ...args,
-      zoom: args.zoom || 10,
-    }
+  export function panToPoint({ point, zoom = 10 }: { point: Point, zoom?: number }) {
+    return {...new MapActions.PanToPoint({
+      point,
+      zoom,
+    })}
+  }
 
-    return {
-      type: mapTypes.MAP_PAN_TO_POINT,
-      point: args.point,
-      zoom: args.zoom,
-    }
-  },
+  export function panToExtent(extent: Extent) {
+    return {...new MapActions.PanToExtent({ extent })}
+  }
 
-  panToExtent(extent: Extent) {
-    return {
-      type: mapTypes.MAP_PAN_TO_EXTENT,
-      extent,
-    }
-  },
-
-  serialize() {
+  export function serialize() {
     return (dispatch: Dispatch<MapState>, getState: () => AppState) => {
       const state = getState()
 
@@ -219,7 +170,7 @@ export const mapActions = {
      */
       let mapView: MapView | null = null
       if (state.map.view) {
-        mapView = {...state.map.view}
+        mapView = { ...state.map.view }
         if (mapView.center) {
           mapView.center[0] = wrap(mapView.center[0], -180, 180)
         }
@@ -236,28 +187,131 @@ export const mapActions = {
       sessionStorage.setItem('bbox', JSON.stringify(bbox))
       sessionStorage.setItem('mapView', JSON.stringify(mapView))
 
-      dispatch({ type: mapTypes.MAP_SERIALIZED })
+      dispatch({...new MapActions.Serialized()})
     }
-  },
+  }
 
-  deserialize() {
-    const deserialized: any = {}
-
+  export function deserialize() {
+    let bbox: Extent | null = null
     try {
-      deserialized.bbox = JSON.parse(sessionStorage.getItem('bbox') || 'null')
+      bbox = JSON.parse(sessionStorage.getItem('bbox') || 'null')
     } catch (error) {
       console.warn('Failed to deserialize "bbox"')
     }
 
+    let view: MapView | null = null
     try {
-      deserialized.view = JSON.parse(sessionStorage.getItem('mapView') || 'null')
+      view = JSON.parse(sessionStorage.getItem('mapView') || 'null')
     } catch (error) {
       console.warn('Failed to deserialize "mapView"')
     }
 
-    return {
-      type: mapTypes.MAP_DESERIALIZED,
-      deserialized,
-    }
-  },
+    return {...new MapActions.Deserialized({
+      bbox,
+      view,
+    })}
+  }
+}
+
+export namespace MapActions {
+  export class Initialized implements Action {
+    static type = 'MAP_INITIALIZED'
+    type = Initialized.type
+    constructor(public payload: {
+      map: NonNullable<typeof mapInitialState.map>
+      collections: NonNullable<typeof mapInitialState.collections>
+    }) {}
+  }
+
+  export class ModeUpdated implements Action {
+    static type = 'MAP_MODE_UPDATED'
+    type = ModeUpdated.type
+    constructor(public payload: {
+      mode: typeof mapInitialState.mode
+    }) {}
+  }
+
+  export class DetectionsUpdated implements Action {
+    static type = 'MAP_DETECTIONS_UPDATED'
+    type = DetectionsUpdated.type
+    constructor(public payload: {
+      detections: typeof mapInitialState.detections
+    }) {}
+  }
+
+  export class FramesUpdated implements Action {
+    static type = 'MAP_FRAMES_UPDATED'
+    type = FramesUpdated.type
+    constructor(public payload: {
+      frames: typeof mapInitialState.frames
+    }) {}
+  }
+
+  export class BboxUpdated implements Action {
+    static type = 'MAP_BBOX_UPDATED'
+    type = BboxUpdated.type
+    constructor(public payload: {
+      bbox: typeof mapInitialState.bbox
+    }) {}
+  }
+
+  export class BboxCleared implements Action {
+    static type = 'MAP_BBOX_CLEARED'
+    type = BboxCleared.type
+  }
+
+  export class SelectedFeatureUpdated implements Action {
+    static type = 'MAP_SELECTED_FEATURE_UPDATED'
+    type = SelectedFeatureUpdated.type
+    constructor(public payload: {
+      selectedFeature: typeof mapInitialState.selectedFeature
+    }) {}
+  }
+
+  export class HoveredFeatureUpdated implements Action {
+    static type = 'MAP_HOVERED_FEATURE_UPDATED'
+    type = HoveredFeatureUpdated.type
+    constructor(public payload: {
+      hoveredFeature: typeof mapInitialState.hoveredFeature
+    }) {}
+  }
+
+  export class ViewUpdated implements Action {
+    static type = 'MAP_VIEW_UPDATED'
+    type = ViewUpdated.type
+    constructor(public payload: {
+      view: NonNullable<typeof mapInitialState.view>
+    }) {}
+  }
+
+  export class PanToPoint implements Action {
+    static type = 'MAP_PAN_TO_POINT'
+    type = PanToPoint.type
+    constructor(public payload: {
+      point: Point
+      zoom: number
+    }) {}
+  }
+
+  export class PanToExtent implements Action {
+    static type = 'MAP_PAN_TO_EXTENT'
+    type = PanToExtent.type
+    constructor(public payload: {
+      extent: Extent
+    }) {}
+  }
+
+  export class Serialized implements Action {
+    static type = 'MAP_SERIALIZED'
+    type = Serialized.type
+  }
+
+  export class Deserialized implements Action {
+    static type = 'MAP_DESERIALIZED'
+    type = Deserialized.type
+    constructor(public payload: {
+      bbox: typeof mapInitialState.bbox
+      view: typeof mapInitialState.view
+    }) {}
+  }
 }

--- a/src/actions/mapActions.ts
+++ b/src/actions/mapActions.ts
@@ -20,7 +20,7 @@ import {wrap} from '../utils/math'
 import {AppState} from '../store'
 import {Extent, Point} from '../utils/geometries'
 import {Action, Dispatch} from 'redux'
-import {MapCollections, mapInitialState, MapState} from '../reducers/mapReducer'
+import {MapCollections, MapState} from '../reducers/mapReducer'
 
 export namespace Map {
   export function initialized(map: ol.Map, collections: MapCollections) {
@@ -218,8 +218,8 @@ export namespace MapActions {
     static type = 'MAP_INITIALIZED'
     type = Initialized.type
     constructor(public payload: {
-      map: NonNullable<typeof mapInitialState.map>
-      collections: NonNullable<typeof mapInitialState.collections>
+      map: NonNullable<MapState['map']>
+      collections: NonNullable<MapState['collections']>
     }) {}
   }
 
@@ -227,7 +227,7 @@ export namespace MapActions {
     static type = 'MAP_MODE_UPDATED'
     type = ModeUpdated.type
     constructor(public payload: {
-      mode: typeof mapInitialState.mode
+      mode: MapState['mode']
     }) {}
   }
 
@@ -235,7 +235,7 @@ export namespace MapActions {
     static type = 'MAP_DETECTIONS_UPDATED'
     type = DetectionsUpdated.type
     constructor(public payload: {
-      detections: typeof mapInitialState.detections
+      detections: MapState['detections']
     }) {}
   }
 
@@ -243,7 +243,7 @@ export namespace MapActions {
     static type = 'MAP_FRAMES_UPDATED'
     type = FramesUpdated.type
     constructor(public payload: {
-      frames: typeof mapInitialState.frames
+      frames: MapState['frames']
     }) {}
   }
 
@@ -251,7 +251,7 @@ export namespace MapActions {
     static type = 'MAP_BBOX_UPDATED'
     type = BboxUpdated.type
     constructor(public payload: {
-      bbox: typeof mapInitialState.bbox
+      bbox: MapState['bbox']
     }) {}
   }
 
@@ -264,7 +264,7 @@ export namespace MapActions {
     static type = 'MAP_SELECTED_FEATURE_UPDATED'
     type = SelectedFeatureUpdated.type
     constructor(public payload: {
-      selectedFeature: typeof mapInitialState.selectedFeature
+      selectedFeature: MapState['selectedFeature']
     }) {}
   }
 
@@ -272,7 +272,7 @@ export namespace MapActions {
     static type = 'MAP_HOVERED_FEATURE_UPDATED'
     type = HoveredFeatureUpdated.type
     constructor(public payload: {
-      hoveredFeature: typeof mapInitialState.hoveredFeature
+      hoveredFeature: MapState['hoveredFeature']
     }) {}
   }
 
@@ -280,7 +280,7 @@ export namespace MapActions {
     static type = 'MAP_VIEW_UPDATED'
     type = ViewUpdated.type
     constructor(public payload: {
-      view: NonNullable<typeof mapInitialState.view>
+      view: NonNullable<MapState['view']>
     }) {}
   }
 
@@ -310,8 +310,8 @@ export namespace MapActions {
     static type = 'MAP_DESERIALIZED'
     type = Deserialized.type
     constructor(public payload: {
-      bbox: typeof mapInitialState.bbox
-      view: typeof mapInitialState.view
+      bbox: MapState['bbox']
+      view: MapState['view']
     }) {}
   }
 }

--- a/src/actions/productLinesActions.ts
+++ b/src/actions/productLinesActions.ts
@@ -18,7 +18,7 @@ import {Action, Dispatch} from 'redux'
 import {getClient} from '../api/session'
 import {JOB_ENDPOINT, PRODUCTLINE_ENDPOINT} from '../config'
 import {Extent} from '../utils/geometries'
-import {ProductLinesState, productLinesInitialState} from '../reducers/productLinesReducer'
+import {ProductLinesState} from '../reducers/productLinesReducer'
 
 export namespace ProductLines {
   export function fetch() {
@@ -89,7 +89,7 @@ export namespace ProductLinesActions {
     static type = 'PRODUCT_LINES_FETCH_SUCCESS'
     type = FetchSuccess.type
     constructor(public payload: {
-      records: typeof productLinesInitialState.records
+      records: ProductLinesState['records']
     }) {}
   }
 
@@ -97,7 +97,7 @@ export namespace ProductLinesActions {
     static type = 'PRODUCT_LINES_FETCH_ERROR'
     type = FetchError.type
     constructor(public payload: {
-      error: typeof productLinesInitialState.fetchError
+      error: ProductLinesState['fetchError']
     }) {}
   }
 
@@ -110,7 +110,7 @@ export namespace ProductLinesActions {
     static type = 'PRODUCT_LINES_FETCH_JOBS_SUCCESS'
     type = FetchJobsSuccess.type
     constructor(public payload: {
-      jobs: typeof productLinesInitialState.jobs
+      jobs: ProductLinesState['jobs']
     }) {}
   }
 
@@ -118,7 +118,7 @@ export namespace ProductLinesActions {
     static type = 'PRODUCT_LINES_FETCH_JOBS_ERROR'
     type = FetchJobsError.type
     constructor(public payload: {
-      error: typeof productLinesInitialState.fetchJobsError
+      error: ProductLinesState['fetchJobsError']
     }) {}
   }
 
@@ -131,7 +131,7 @@ export namespace ProductLinesActions {
     static type = 'PRODUCT_LINES_CREATE_PRODUCT_LINE_SUCCESS'
     type = CreateProductLineSuccess.type
     constructor(public payload: {
-      createdProductLine: NonNullable<typeof productLinesInitialState.createdProductLine>
+      createdProductLine: NonNullable<ProductLinesState['createdProductLine']>
     }) {}
   }
 
@@ -139,7 +139,7 @@ export namespace ProductLinesActions {
     static type = 'PRODUCT_LINES_CREATE_PRODUCT_LINE_ERROR'
     type = CreateProductLineError.type
     constructor(public payload: {
-      error: typeof productLinesInitialState.createProductLineError
+      error: ProductLinesState['createProductLineError']
     }) {}
   }
 }

--- a/src/actions/routeActions.ts
+++ b/src/actions/routeActions.ts
@@ -14,10 +14,47 @@
  * limitations under the License.
  **/
 
+import {Action} from 'redux'
 import {generateRoute} from '../utils/routeUtils'
+import {routeInitialState} from '../reducers/routeReducer'
 
-export const routeTypes: ActionTypes = {
-  ROUTE_CHANGED: 'ROUTE_CHANGED',
+export namespace Route {
+  export function navigateTo(args: RouteNavigateToArgs) {
+    args = {
+      ...args,
+      pushHistory: (args.pushHistory != null) ? args.pushHistory : true,
+    }
+
+    const route = generateRoute(args.loc)
+
+    if (args.pushHistory) {
+      history.pushState(null, '', route.href)
+    }
+
+    return {...new RouteActions.Changed({
+      hash: route.hash,
+      href: route.href,
+      jobIds: route.jobIds,
+      pathname: route.pathname,
+      search: route.search,
+      selectedFeature: route.selectedFeature,
+    })}
+  }
+}
+
+export namespace RouteActions {
+  export class Changed implements Action {
+    static type = 'ROUTE_CHANGED'
+    type = Changed.type
+    constructor(public payload: {
+      hash: typeof routeInitialState.hash
+      href: typeof routeInitialState.href
+      jobIds: typeof routeInitialState.jobIds
+      pathname: typeof routeInitialState.pathname
+      search: typeof routeInitialState.search
+      selectedFeature: typeof routeInitialState.selectedFeature
+    }) {}
+  }
 }
 
 export interface RouteLocation {
@@ -30,29 +67,4 @@ export interface RouteLocation {
 export interface RouteNavigateToArgs {
   loc: RouteLocation
   pushHistory?: boolean
-}
-
-export const routeActions = {
-  navigateTo(args: RouteNavigateToArgs) {
-    args = {
-      ...args,
-      pushHistory: (args.pushHistory != null) ? args.pushHistory : true,
-    }
-
-    const route = generateRoute(args.loc)
-
-    if (args.pushHistory) {
-      history.pushState(null, '', route.href)
-    }
-
-    return {
-      type: routeTypes.ROUTE_CHANGED,
-      hash: route.hash,
-      href: route.href,
-      jobIds: route.jobIds,
-      pathname: route.pathname,
-      search: route.search,
-      selectedFeature: route.selectedFeature,
-    }
-  },
 }

--- a/src/actions/routeActions.ts
+++ b/src/actions/routeActions.ts
@@ -16,7 +16,7 @@
 
 import {Action} from 'redux'
 import {generateRoute} from '../utils/routeUtils'
-import {routeInitialState} from '../reducers/routeReducer'
+import {RouteState} from '../reducers/routeReducer'
 
 export namespace Route {
   export function navigateTo(args: RouteNavigateToArgs) {
@@ -47,12 +47,12 @@ export namespace RouteActions {
     static type = 'ROUTE_CHANGED'
     type = Changed.type
     constructor(public payload: {
-      hash: typeof routeInitialState.hash
-      href: typeof routeInitialState.href
-      jobIds: typeof routeInitialState.jobIds
-      pathname: typeof routeInitialState.pathname
-      search: typeof routeInitialState.search
-      selectedFeature: typeof routeInitialState.selectedFeature
+      hash: RouteState['hash']
+      href: RouteState['href']
+      jobIds: RouteState['jobIds']
+      pathname: RouteState['pathname']
+      search: RouteState['search']
+      selectedFeature: RouteState['selectedFeature']
     }) {}
   }
 }

--- a/src/actions/tourActions.ts
+++ b/src/actions/tourActions.ts
@@ -14,50 +14,25 @@
  * limitations under the License.
  **/
 
-import {Dispatch} from 'redux'
+import {Action, Dispatch} from 'redux'
 import {scrollIntoView} from '../utils/domUtils'
 import {AppState} from '../store'
-import {TourState} from '../reducers/tourReducer'
+import {tourInitialState, TourState} from '../reducers/tourReducer'
 
-export const tourTypes: ActionTypes = {
-  TOUR_STEPS_UPDATED: 'TOUR_STEPS_UPDATED',
-  TOUR_STARTED: 'TOUR_STARTED',
-  TOUR_ENDED: 'TOUR_ENDED',
-  TOUR_STEP_CHANGING: 'TOUR_STEP_CHANGING',
-  TOUR_STEP_CHANGE_ERROR: 'TOUR_STEP_CHANGE_ERROR',
-  TOUR_STEP_CHANGE_SUCCESS: 'TOUR_STEP_CHANGE_SUCCESS',
-}
+export namespace Tour {
+  export function setSteps(steps: TourStep[]) {
+    return {...new TourActions.StepsUpdated({ steps })}
+  }
 
-export interface TourStep {
-  step: number
-  selector: string
-  title: string | JSX.Element
-  body: string | JSX.Element
-  horizontalOffset?: number
-  verticalOffset?: number
-  position?: 'left' | 'right' | 'top' | 'topLeft' | 'bottom' | 'bottomLeft'
-  hideArrow?: boolean
-  before?: () => void
-  after?: () => void
-}
+  export function start() {
+    return {...new TourActions.Started()}
+  }
 
-export const tourActions = {
-  setSteps(steps: TourStep[]) {
-    return {
-      type: tourTypes.TOUR_STEPS_UPDATED,
-      steps,
-    }
-  },
+  export function end() {
+    return {...new TourActions.Ended()}
+  }
 
-  start() {
-    return { type: tourTypes.TOUR_STARTED }
-  },
-
-  end() {
-    return { type: tourTypes.TOUR_ENDED }
-  },
-
-  goToStep(step: number) {
+  export function goToStep(step: number) {
     return async (dispatch: Dispatch<TourState>, getState: () => AppState) => {
       const state = getState()
 
@@ -79,7 +54,7 @@ export const tourActions = {
         return
       }
 
-      dispatch({ type: tourTypes.TOUR_STEP_CHANGING })
+      dispatch({...new TourActions.StepChanging()})
 
       try {
         if (curStep.after) {
@@ -96,18 +71,66 @@ export const tourActions = {
           alert("Sorry, it seems you can't go back from here.")
         }
 
-        dispatch({
-          type: tourTypes.TOUR_STEP_CHANGE_ERROR,
-          error,
-        })
+        dispatch({...new TourActions.StepChangeError({ error })})
 
         return
       }
 
-      dispatch({
-        type: tourTypes.TOUR_STEP_CHANGE_SUCCESS,
-        step,
-      })
+      dispatch({...new TourActions.StepChangeSuccess({ step })})
     }
-  },
+  }
+}
+
+export namespace TourActions {
+  export class StepsUpdated implements Action {
+    static type = 'TOUR_STEPS_UPDATED'
+    type = StepsUpdated.type
+    constructor(public payload: {
+      steps: typeof tourInitialState.steps
+    }) {}
+  }
+
+  export class Started implements Action {
+    static type = 'TOUR_STARTED'
+    type = Started.type
+  }
+
+  export class Ended implements Action {
+    static type = 'TOUR_ENDED'
+    type = Ended.type
+  }
+
+  export class StepChanging implements Action {
+    static type = 'TOUR_STEP_CHANGING'
+    type = StepChanging.type
+  }
+
+  export class StepChangeSuccess implements Action {
+    static type = 'TOUR_STEP_CHANGE_SUCCESS'
+    type = StepChangeSuccess.type
+    constructor(public payload: {
+      step: typeof tourInitialState.step
+    }) {}
+  }
+
+  export class StepChangeError implements Action {
+    static type = 'TOUR_STEP_CHANGE_ERROR'
+    type = StepChangeError.type
+    constructor(public payload: {
+      error: typeof tourInitialState.error
+    }) {}
+  }
+}
+
+export interface TourStep {
+  step: number
+  selector: string
+  title: string | JSX.Element
+  body: string | JSX.Element
+  horizontalOffset?: number
+  verticalOffset?: number
+  position?: 'left' | 'right' | 'top' | 'topLeft' | 'bottom' | 'bottomLeft'
+  hideArrow?: boolean
+  before?: () => void
+  after?: () => void
 }

--- a/src/actions/tourActions.ts
+++ b/src/actions/tourActions.ts
@@ -17,7 +17,7 @@
 import {Action, Dispatch} from 'redux'
 import {scrollIntoView} from '../utils/domUtils'
 import {AppState} from '../store'
-import {tourInitialState, TourState} from '../reducers/tourReducer'
+import {TourState} from '../reducers/tourReducer'
 
 export namespace Tour {
   export function setSteps(steps: TourStep[]) {
@@ -86,7 +86,7 @@ export namespace TourActions {
     static type = 'TOUR_STEPS_UPDATED'
     type = StepsUpdated.type
     constructor(public payload: {
-      steps: typeof tourInitialState.steps
+      steps: TourState['steps']
     }) {}
   }
 
@@ -109,7 +109,7 @@ export namespace TourActions {
     static type = 'TOUR_STEP_CHANGE_SUCCESS'
     type = StepChangeSuccess.type
     constructor(public payload: {
-      step: typeof tourInitialState.step
+      step: TourState['step']
     }) {}
   }
 
@@ -117,7 +117,7 @@ export namespace TourActions {
     static type = 'TOUR_STEP_CHANGE_ERROR'
     type = StepChangeError.type
     constructor(public payload: {
-      error: typeof tourInitialState.error
+      error: TourState['error']
     }) {}
   }
 }

--- a/src/actions/userActions.ts
+++ b/src/actions/userActions.ts
@@ -97,7 +97,7 @@ export namespace UserActions {
     static type = 'USER_DESERIALIZED'
     type = Deserialized.type
     constructor(public payload: {
-      isSessionExpired: typeof userInitialState.isSessionExpired
+      isSessionExpired: UserState['isSessionExpired']
     }) {}
   }
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -21,7 +21,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {Modal} from './Modal'
 import {BrowsersSupported} from './BrowserSupport'
-import {routeActions, RouteNavigateToArgs} from '../actions/routeActions'
+import {Route, RouteNavigateToArgs} from '../actions/routeActions'
 
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
 type Props = DispatchProps
@@ -60,7 +60,7 @@ export class About extends React.Component<Props> {
   }
 
   private handleDismiss() {
-    this.props.actions.route.navigateTo({
+    this.props.dispatch.route.navigateTo({
       loc: {
         pathname: '/',
       },
@@ -70,9 +70,9 @@ export class About extends React.Component<Props> {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       route: {
-        navigateTo: (args: RouteNavigateToArgs) => dispatch(routeActions.navigateTo(args)),
+        navigateTo: (args: RouteNavigateToArgs) => dispatch(Route.navigateTo(args)),
       },
     },
   }

--- a/src/components/ActivityTable.tsx
+++ b/src/components/ActivityTable.tsx
@@ -24,7 +24,7 @@ import {LoadingAnimation} from './LoadingAnimation'
 import {normalizeSceneId} from './SceneFeatureDetails'
 import {JOB_ENDPOINT} from '../config'
 import {AppState} from '../store'
-import {mapActions} from '../actions/mapActions'
+import {Map} from '../actions/mapActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -68,8 +68,8 @@ export const ActivityTable = (props: Props) => (
             key={job.id}
             className={props.selectedJobIds.includes(job.id) ? styles.isActive : ''}
             onClick={() => props.onRowClick(job)}
-            onMouseEnter={() => props.actions.map.setHoveredFeature(job)}
-            onMouseLeave={() => props.actions.map.setHoveredFeature(null)}
+            onMouseEnter={() => props.dispatch.map.setHoveredFeature(job)}
+            onMouseLeave={() => props.dispatch.map.setHoveredFeature(null)}
           >
             <td>{getSceneId(job)}</td>
             {/*<td>{getCapturedOn(job)}</td>
@@ -142,10 +142,10 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       map: {
         setHoveredFeature: (hoveredFeature: beachfront.Job | null) => (
-          dispatch(mapActions.setHoveredFeature(hoveredFeature))
+          dispatch(Map.setHoveredFeature(hoveredFeature))
         ),
       },
     },

--- a/src/components/CatalogSearchCriteria.tsx
+++ b/src/components/CatalogSearchCriteria.tsx
@@ -26,9 +26,9 @@ import * as moment from 'moment'
 import {getClient} from '../api/session'
 import StaticMinimap from './StaticMinimap'
 import {SCENE_TILE_PROVIDERS} from '../config'
-import {catalogActions, CatalogUpdateSearchCriteriaArgs} from '../actions/catalogActions'
+import {Catalog, CatalogUpdateSearchCriteriaArgs} from '../actions/catalogActions'
 import {AppState} from '../store'
-import {mapActions} from '../actions/mapActions'
+import {Map} from '../actions/mapActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -57,7 +57,7 @@ export class CatalogSearchCriteria extends React.Component<Props> {
       <div className={styles.root}>
         <div className={styles.minimap}>
           <StaticMinimap />
-          <div className={styles.clearBbox} onClick={this.props.actions.map.clearBbox}>
+          <div className={styles.clearBbox} onClick={this.props.dispatch.map.clearBbox}>
             <i className="fa fa-times-circle"/> Clear
           </div>
         </div>
@@ -156,29 +156,29 @@ export class CatalogSearchCriteria extends React.Component<Props> {
   }
 
   private handleSourceChange(e: FormEvent) {
-    this.props.actions.catalog.updateSearchCriteria({
+    this.props.dispatch.catalog.updateSearchCriteria({
       source: (e.target as HTMLSelectElement).value,
     })
   }
 
   private handleApiKeyChange(e: FormEvent) {
-    this.props.actions.catalog.setApiKey((e.target as HTMLInputElement).value)
+    this.props.dispatch.catalog.setApiKey((e.target as HTMLInputElement).value)
   }
 
   private handleDateOfCaptureFromChange(e: FormEvent) {
-    this.props.actions.catalog.updateSearchCriteria({
+    this.props.dispatch.catalog.updateSearchCriteria({
       dateFrom: (e.target as HTMLInputElement).value,
     })
   }
 
   private handleDateOfCaptureToChange(e: FormEvent) {
-    this.props.actions.catalog.updateSearchCriteria({
+    this.props.dispatch.catalog.updateSearchCriteria({
       dateTo: (e.target as HTMLInputElement).value,
     })
   }
 
   private handleCloudCoverChange(e: FormEvent) {
-    this.props.actions.catalog.updateSearchCriteria({
+    this.props.dispatch.catalog.updateSearchCriteria({
       cloudCover: parseInt((e.target as HTMLInputElement).value, 10),
     })
   }
@@ -285,15 +285,15 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       catalog: {
-        setApiKey: (apiKey: string) => dispatch(catalogActions.setApiKey(apiKey)),
+        setApiKey: (apiKey: string) => dispatch(Catalog.setApiKey(apiKey)),
         updateSearchCriteria: (args: CatalogUpdateSearchCriteriaArgs) => (
-          dispatch(catalogActions.updateSearchCriteria(args))
+          dispatch(Catalog.updateSearchCriteria(args))
         ),
       },
       map: {
-        clearBbox: () => dispatch(mapActions.clearBbox()),
+        clearBbox: () => dispatch(Map.clearBbox()),
       },
     },
   }

--- a/src/components/CreateJob.tsx
+++ b/src/components/CreateJob.tsx
@@ -26,7 +26,7 @@ import {PrimaryMap} from './PrimaryMap'
 import {normalizeSceneId} from './SceneFeatureDetails'
 import {TYPE_SCENE} from '../constants'
 import {AppState} from '../store'
-import {jobsActions, JobsCreateJobArgs} from '../actions/jobsActions'
+import {Jobs, JobsCreateJobArgs} from '../actions/jobsActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -72,7 +72,7 @@ export class CreateJob extends React.Component<Props, State> {
 
         // Reset the algorithm error.
         if (this.props.jobs.createJobError) {
-          this.props.actions.jobs.dismissCreateJobError()
+          this.props.dispatch.jobs.dismissCreateJobError()
         }
       }
 
@@ -135,7 +135,7 @@ export class CreateJob extends React.Component<Props, State> {
       throw new Error('Unable to submit: selectedScene is null!')
     }
 
-    this.props.actions.jobs.createJob({
+    this.props.dispatch.jobs.createJob({
       algorithmId: algorithm.id,
       computeMask: this.state.computeMask,
       name: this.state.name,
@@ -163,10 +163,10 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       jobs: {
-        createJob: (args: JobsCreateJobArgs) => dispatch(jobsActions.createJob(args)),
-        dismissCreateJobError: () => dispatch(jobsActions.dismissCreateJobError()),
+        createJob: (args: JobsCreateJobArgs) => dispatch(Jobs.createJob(args)),
+        dismissCreateJobError: () => dispatch(Jobs.dismissCreateJobError()),
       },
     },
   }

--- a/src/components/CreateProductLine.tsx
+++ b/src/components/CreateProductLine.tsx
@@ -26,7 +26,7 @@ import {
   SOURCE_DEFAULT,
 } from '../constants'
 import {AppState} from '../store'
-import {ProductLinesCreateArgs, productLinesActions} from '../actions/productLinesActions'
+import {ProductLinesCreateArgs, ProductLines} from '../actions/productLinesActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -139,7 +139,7 @@ export class CreateProductLine extends React.Component<Props, State> {
       throw new Error('Unable to submit: bbox is null!')
     }
 
-    this.props.actions.productLines.create({
+    this.props.dispatch.productLines.create({
       algorithmId: this.state.algorithm.id,
       bbox: this.props.map.bbox,
       category: null,
@@ -168,9 +168,9 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       productLines: {
-        create: (args: ProductLinesCreateArgs) => dispatch(productLinesActions.create(args)),
+        create: (args: ProductLinesCreateArgs) => dispatch(ProductLines.create(args)),
       },
     },
   }

--- a/src/components/ImagerySearch.tsx
+++ b/src/components/ImagerySearch.tsx
@@ -25,7 +25,7 @@ import CatalogSearchCriteria from './CatalogSearchCriteria'
 import {LoadingAnimation} from './LoadingAnimation'
 import { SCENE_TILE_PROVIDERS } from '../config'
 import {AppState} from '../store'
-import {catalogActions, CatalogSearchArgs} from '../actions/catalogActions'
+import {Catalog, CatalogSearchArgs} from '../actions/catalogActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -51,7 +51,7 @@ export class ImagerySearch extends React.Component<Props> {
           <div className={styles.controls}>
             <button
               type="button"
-              onClick={this.props.actions.catalog.resetSearchCriteria}
+              onClick={this.props.dispatch.catalog.resetSearchCriteria}
             >
               Reset Defaults
             </button>
@@ -91,7 +91,7 @@ export class ImagerySearch extends React.Component<Props> {
   private handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     event.stopPropagation()
-    this.props.actions.catalog.search()
+    this.props.dispatch.catalog.search()
   }
 }
 
@@ -104,10 +104,10 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       catalog: {
-        resetSearchCriteria: () => dispatch(catalogActions.resetSearchCriteria()),
-        search: (args?: CatalogSearchArgs) => dispatch(catalogActions.search(args)),
+        resetSearchCriteria: () => dispatch(Catalog.resetSearchCriteria()),
+        search: (args?: CatalogSearchArgs) => dispatch(Catalog.search(args)),
       },
     },
   }

--- a/src/components/JobStatus.tsx
+++ b/src/components/JobStatus.tsx
@@ -35,11 +35,11 @@ import {
   STATUS_FAIL,
 } from '../constants'
 import {connect} from 'react-redux'
-import {mapActions} from '../actions/mapActions'
-import {jobsActions} from '../actions/jobsActions'
+import {Map} from '../actions/mapActions'
+import {Jobs} from '../actions/jobsActions'
 import {AppState} from '../store'
 import {Extent, featureToExtentWrapped} from '../utils/geometries'
-import {routeActions, RouteNavigateToArgs} from '../actions/routeActions'
+import {Route, RouteNavigateToArgs} from '../actions/routeActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -94,7 +94,7 @@ export class JobStatus extends React.Component<Props, State> {
 
   render() {
     const { id, properties } = this.props.job
-    const hasError = properties.errorDetails ? true : false
+    const hasError = !!properties.errorDetails
     const timeOfCollect = moment.utc(properties.time_of_collect).local().format('llll')
 
     return (
@@ -244,7 +244,7 @@ export class JobStatus extends React.Component<Props, State> {
       this.toggleExpansion()
     }
 
-    this.props.actions.map.setSelectedFeature(this.props.job)
+    this.props.dispatch.map.setSelectedFeature(this.props.job)
   }
 
   private handleDownloadProgress(loaded: number, total: number) {
@@ -268,7 +268,7 @@ export class JobStatus extends React.Component<Props, State> {
   }
 
   private handleRemoveJobConfirm() {
-    this.props.actions.jobs.deleteJob(this.props.job)
+    this.props.dispatch.jobs.deleteJob(this.props.job)
   }
 
   private handleViewOnMapClick(loc: Location) {
@@ -276,13 +276,13 @@ export class JobStatus extends React.Component<Props, State> {
       throw new Error('Map is null!')
     }
 
-    this.props.actions.route.navigateTo({ loc })
+    this.props.dispatch.route.navigateTo({ loc })
     const feature = this.props.jobs.records.find(j => loc.search.includes(j.id))
     if (!feature) {
       throw new Error('Could not find feature!')
     }
 
-    this.props.actions.map.panToExtent(featureToExtentWrapped(this.props.map.map, feature))
+    this.props.dispatch.map.panToExtent(featureToExtentWrapped(this.props.map.map, feature))
   }
 
   private toggleExpansion() {
@@ -312,16 +312,16 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       map: {
-        setSelectedFeature: (feature: GeoJSON.Feature<any> | null) => dispatch(mapActions.setSelectedFeature(feature)),
-        panToExtent: (extent: Extent) => dispatch(mapActions.panToExtent(extent)),
+        setSelectedFeature: (feature: GeoJSON.Feature<any> | null) => dispatch(Map.setSelectedFeature(feature)),
+        panToExtent: (extent: Extent) => dispatch(Map.panToExtent(extent)),
       },
       jobs: {
-        deleteJob: (job: beachfront.Job) => dispatch(jobsActions.deleteJob(job)),
+        deleteJob: (job: beachfront.Job) => dispatch(Jobs.deleteJob(job)),
       },
       route: {
-        navigateTo: (args: RouteNavigateToArgs) => dispatch(routeActions.navigateTo(args)),
+        navigateTo: (args: RouteNavigateToArgs) => dispatch(Route.navigateTo(args)),
       },
     },
   }

--- a/src/components/JobStatusList.tsx
+++ b/src/components/JobStatusList.tsx
@@ -21,7 +21,7 @@ import {connect} from 'react-redux'
 import JobStatus from './JobStatus'
 import * as moment from 'moment'
 import {AppState} from '../store'
-import {jobsActions} from '../actions/jobsActions'
+import {Jobs} from '../actions/jobsActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -64,7 +64,7 @@ export class JobStatusList extends React.Component<Props, State> {
             <li className={styles.communicationError}>
               <h4><i className="fa fa-warning"/> Communication Error</h4>
               <p>Cannot communicate with the server. (<code>{this.props.jobs.fetchError.toString()}</code>)</p>
-              <button onClick={this.props.actions.jobs.fetch}>Retry</button>
+              <button onClick={this.props.dispatch.jobs.fetch}>Retry</button>
             </li>
           )}
 
@@ -149,9 +149,9 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       jobs: {
-        fetch: () => dispatch(jobsActions.fetch()),
+        fetch: () => dispatch(Jobs.fetch()),
       },
     },
   }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,8 +23,8 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {Link} from './Link'
 import {USER_GUIDE_URL} from '../config'
-import {routeActions, RouteNavigateToArgs} from '../actions/routeActions'
-import {tourActions} from '../actions/tourActions'
+import {Route, RouteNavigateToArgs} from '../actions/routeActions'
+import {Tour} from '../actions/tourActions'
 
 const Icon = ({ path, size = 40 }: { path: string, size?: number }) => (
   <svg className={styles.icon} viewBox={`0 0 ${size} ${size}`}>
@@ -91,7 +91,7 @@ export class Navigation extends React.Component<Props> {
       </li>
       */}
           <li>
-            <a className={styles.linkTour} onClick={this.props.actions.tour.start}>
+            <a className={styles.linkTour} onClick={this.props.dispatch.tour.start}>
               <Icon path="M4 16c0 .88.39 1.67 1 2.22V20c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h8v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1.78c.61-.55 1-1.34 1-2.22V6c0-3.5-3.58-4-8-4s-8 .5-8 4v10zm3.5 1c-.83 0-1.5-.67-1.5-1.5S6.67 14 7.5 14s1.5.67 1.5 1.5S8.33 17 7.5 17zm9 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm1.5-6H6V6h12v5z" size={25}/>
               <span className={styles.label}>Take a Tour</span>
             </a>
@@ -103,7 +103,7 @@ export class Navigation extends React.Component<Props> {
   }
 
   private handleClick(loc: { pathname: string, search: string, hash: string }) {
-    this.props.actions.route.navigateTo({ loc })
+    this.props.dispatch.route.navigateTo({ loc })
   }
 }
 
@@ -130,12 +130,12 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       route: {
-        navigateTo: (args: RouteNavigateToArgs) => dispatch(routeActions.navigateTo(args)),
+        navigateTo: (args: RouteNavigateToArgs) => dispatch(Route.navigateTo(args)),
       },
       tour: {
-        start: () => dispatch(tourActions.start()),
+        start: () => dispatch(Tour.start()),
       },
     },
   }

--- a/src/components/ProductLine.tsx
+++ b/src/components/ProductLine.tsx
@@ -20,9 +20,9 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import * as moment from 'moment'
 import ActivityTable from './ActivityTable'
-import {ProductLinesFetchJobsArgs, productLinesActions} from '../actions/productLinesActions'
-import {mapActions, MapPanToPointArgs} from '../actions/mapActions'
-import {getFeatureCenter} from '../utils/geometries'
+import {ProductLinesFetchJobsArgs, ProductLines} from '../actions/productLinesActions'
+import {Map} from '../actions/mapActions'
+import {getFeatureCenter, Point} from '../utils/geometries'
 
 const LAST_24_HOURS = {value: 'PT24H', label: 'Last 24 Hours'}
 const LAST_7_DAYS = {value: 'P7D', label: 'Last 7 Days'}
@@ -58,13 +58,13 @@ export class ProductLine extends React.Component<Props, State> {
 
   componentDidUpdate(_: Props, prevState: State) {
     if (this.state.isExpanded && (prevState.isExpanded !== this.state.isExpanded || prevState.duration !== this.state.duration)) {
-      this.props.actions.productLines.fetchJobs({
+      this.props.dispatch.productLines.fetchJobs({
         productLineId: this.props.productLine.id,
         sinceDate: generateSinceDate(this.state.duration, this.props.productLine),
       })
     }
     if (prevState.isExpanded && !this.state.isExpanded && this.state.selectedJobs.length) {
-      this.props.actions.map.setSelectedFeature(null)
+      this.props.dispatch.map.setSelectedFeature(null)
     }
   }
 
@@ -135,17 +135,17 @@ export class ProductLine extends React.Component<Props, State> {
 
   private handleJobRowClick(job: beachfront.Job) {
     if (this.state.selectedJobs.some(j => j.id === job.id)) {
-      this.props.actions.map.setSelectedFeature(null)
+      this.props.dispatch.map.setSelectedFeature(null)
       this.setState({ selectedJobs: [] })
     }
     else {
-      this.props.actions.map.setSelectedFeature(job)
+      this.props.dispatch.map.setSelectedFeature(job)
       this.setState({ selectedJobs: [job] })
     }
   }
 
   private handleViewOnMap() {
-    this.props.actions.map.panToPoint({
+    this.props.dispatch.map.panToPoint({
       point: getFeatureCenter(this.props.productLine),
       zoom: 3.5,
     })
@@ -177,13 +177,13 @@ function generateSinceDate(offset: string, productLine: beachfront.ProductLine) 
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       productLines: {
-        fetchJobs: (args: ProductLinesFetchJobsArgs) => dispatch(productLinesActions.fetchJobs(args)),
+        fetchJobs: (args: ProductLinesFetchJobsArgs) => dispatch(ProductLines.fetchJobs(args)),
       },
       map: {
-        setSelectedFeature: (feature: GeoJSON.Feature<any> | null) => dispatch(mapActions.setSelectedFeature(feature)),
-        panToPoint: (args: MapPanToPointArgs) => dispatch(mapActions.panToPoint(args)),
+        setSelectedFeature: (feature: GeoJSON.Feature<any> | null) => dispatch(Map.setSelectedFeature(feature)),
+        panToPoint: (args: { point: Point, zoom?: number }) => dispatch(Map.panToPoint(args)),
       },
     },
   }

--- a/src/components/ProductLineList.tsx
+++ b/src/components/ProductLineList.tsx
@@ -21,7 +21,7 @@ import {connect} from 'react-redux'
 import {LoadingAnimation} from './LoadingAnimation'
 import ProductLine from './ProductLine'
 import {AppState} from '../store'
-import {productLinesActions} from '../actions/productLinesActions'
+import {ProductLines} from '../actions/productLinesActions'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
@@ -48,7 +48,7 @@ export class ProductLineList extends React.Component<Props> {
                 ? 'Cannot communicate with the server'
                 : 'An error is preventing the display of product lines'
               }. (<code>{this.props.productLines.fetchError.message}</code>)</p>
-              <button onClick={this.props.actions.productLines.fetch}>Retry</button>
+              <button onClick={this.props.dispatch.productLines.fetch}>Retry</button>
             </li>
           )}
           {this.props.productLines.records.map(productLine => (
@@ -80,9 +80,9 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       productLines: {
-        fetch: () => dispatch(productLinesActions.fetch()),
+        fetch: () => dispatch(ProductLines.fetch()),
       },
     },
   }

--- a/src/components/SessionExpired.tsx
+++ b/src/components/SessionExpired.tsx
@@ -19,7 +19,7 @@ const styles = require('./SessionExpired.css')
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {Modal} from './Modal'
-import {userActions} from '../actions/userActions'
+import {User} from '../actions/userActions'
 
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
 type Props = DispatchProps
@@ -45,15 +45,15 @@ export class SessionExpired extends React.Component<Props> {
   }
 
   private handleDismiss() {
-    this.props.actions.user.clearSession()
+    this.props.dispatch.user.clearSession()
   }
 }
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       user: {
-        clearSession: () => dispatch(userActions.clearSession()),
+        clearSession: () => dispatch(User.clearSession()),
       },
     },
   }

--- a/src/components/SessionLoggedOut.tsx
+++ b/src/components/SessionLoggedOut.tsx
@@ -19,7 +19,7 @@ const styles = require('./SessionLoggedOut.css')
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {Modal} from './Modal'
-import {userActions} from '../actions/userActions'
+import {User} from '../actions/userActions'
 
 type DispatchProps = ReturnType<typeof mapDispatchToProps>
 type Props = DispatchProps
@@ -45,15 +45,15 @@ export class SessionLoggedOut extends React.Component<Props> {
   }
 
   private handleInitialize() {
-    this.props.actions.user.sessionLogout()
+    this.props.dispatch.user.sessionLogout()
   }
 }
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       user: {
-        sessionLogout: () => dispatch(userActions.sessionLogout()),
+        sessionLogout: () => dispatch(User.sessionLogout()),
       },
     },
   }

--- a/src/components/UserTour.tsx
+++ b/src/components/UserTour.tsx
@@ -16,16 +16,16 @@
 
 import * as React from 'react'
 import {TYPE_SCENE} from '../constants'
-import Tour from 'react-user-tour'
+import ReactUserTour from 'react-user-tour'
 import {TOUR} from '../config'
 import {query} from '../utils/domUtils'
 import {connect} from 'react-redux'
-import {catalogActions, CatalogUpdateSearchCriteriaArgs} from '../actions/catalogActions'
-import {mapActions, MapPanToPointArgs} from '../actions/mapActions'
+import {Catalog, CatalogUpdateSearchCriteriaArgs} from '../actions/catalogActions'
+import {Map} from '../actions/mapActions'
 import {AppState} from '../store'
-import {RouteNavigateToArgs, routeActions, RouteLocation} from '../actions/routeActions'
-import {Extent} from '../utils/geometries'
-import {tourActions, TourStep} from '../actions/tourActions'
+import {RouteNavigateToArgs, Route, RouteLocation} from '../actions/routeActions'
+import {Extent, Point} from '../utils/geometries'
+import {Tour, TourStep} from '../actions/tourActions'
 
 const styles: any = require('./UserTour.css')
 
@@ -94,7 +94,7 @@ export class UserTour extends React.Component<Props> {
   }
 
   componentDidMount() {
-    this.props.actions.tour.setSteps([
+    this.props.dispatch.tour.setSteps([
       {
         step: 1,
         selector: '.Navigation-linkTour',
@@ -141,13 +141,13 @@ export class UserTour extends React.Component<Props> {
         </div>,
         before: () => this.navigateTo('/'),
         after: async () => {
-          this.props.actions.catalog.resetSearchCriteria()
-          this.props.actions.catalog.serialize()
+          this.props.dispatch.catalog.resetSearchCriteria()
+          this.props.dispatch.catalog.serialize()
 
           await this.navigateTo('/')
 
           // Pan to the center of the bound box that we will highlight later.
-          this.props.actions.map.panToPoint({
+          this.props.dispatch.map.panToPoint({
             point: [
               (this.bbox[0] + this.bbox[2]) / 2,
               (this.bbox[1] + this.bbox[3]) / 2,
@@ -176,7 +176,7 @@ export class UserTour extends React.Component<Props> {
           But we&apos;ll do it for you this time.
         </div>,
         before: async () => {
-          this.props.actions.map.clearBbox()
+          this.props.dispatch.map.clearBbox()
           await this.navigateTo('/create-job')
         },
         after: () => {
@@ -192,7 +192,7 @@ export class UserTour extends React.Component<Props> {
               const interval = setInterval(() => {
                 ++i
 
-                this.props.actions.map.updateBbox([
+                this.props.dispatch.map.updateBbox([
                   this.bbox[0],
                   this.bbox[1],
                   this.bbox[0] + i / n * (this.bbox[2] - this.bbox[0]),
@@ -201,13 +201,13 @@ export class UserTour extends React.Component<Props> {
 
                 if (i >= n) {
                   clearInterval(interval)
-                  this.props.actions.map.updateBbox(this.bbox)
+                  this.props.dispatch.map.updateBbox(this.bbox)
                   resolve()
                 }
               }, duration / n)
             }
 
-            this.props.actions.map.updateBbox(this.bbox)
+            this.props.dispatch.map.updateBbox(this.bbox)
           })
         },
       },
@@ -221,7 +221,7 @@ export class UserTour extends React.Component<Props> {
         </div>,
         after: () => {
           if (this.props.catalog.searchCriteria.source !== this.searchCriteria.source) {
-            this.props.actions.catalog.updateSearchCriteria({
+            this.props.dispatch.catalog.updateSearchCriteria({
               source: this.searchCriteria.source,
             })
           }
@@ -247,7 +247,7 @@ export class UserTour extends React.Component<Props> {
         </div>,
         after: () => {
           const input = query(`.${styles.apiKey} input`) as HTMLInputElement
-          this.props.actions.catalog.setApiKey(input.value)
+          this.props.dispatch.catalog.setApiKey(input.value)
         },
       },
       {
@@ -265,7 +265,7 @@ export class UserTour extends React.Component<Props> {
             await this.pace(search.dateFrom, (_: any, s: string) => fromElem.value = s)
           }
 
-          this.props.actions.catalog.updateSearchCriteria({
+          this.props.dispatch.catalog.updateSearchCriteria({
             dateFrom: search.dateFrom,
           })
 
@@ -274,7 +274,7 @@ export class UserTour extends React.Component<Props> {
             await this.pace(search.dateTo, (_: any, s: string) => toElem.value = s)
           }
 
-          this.props.actions.catalog.updateSearchCriteria({
+          this.props.dispatch.catalog.updateSearchCriteria({
             dateTo: search.dateTo,
           })
         },
@@ -312,7 +312,7 @@ export class UserTour extends React.Component<Props> {
                   setTimeout(resolve, 100)
                 } else {
                   setTimeout(() => {
-                    this.props.actions.catalog.updateSearchCriteria({
+                    this.props.dispatch.catalog.updateSearchCriteria({
                       cloudCover: i,
                     })
 
@@ -403,7 +403,7 @@ export class UserTour extends React.Component<Props> {
             if (feature.properties) {
               feature.properties.type = TYPE_SCENE
             }
-            this.props.actions.map.setSelectedFeature(feature)
+            this.props.dispatch.map.setSelectedFeature(feature)
             setTimeout(resolve, 100)
           })
         },
@@ -609,20 +609,20 @@ export class UserTour extends React.Component<Props> {
           onKeyPress={this.onKeyPress}
           style={{ display: this.props.tour.error ? 'none' : 'block' }}
         >
-          <Tour
+          <ReactUserTour
             active={this.props.tour.inProgress}
             arrow={Arrow}
             buttonStyle={{}}
             closeButtonText="&#10799;"
-            onBack={this.props.actions.tour.goToStep}
-            onCancel={this.props.actions.tour.end}
-            onNext={this.props.actions.tour.goToStep}
+            onBack={this.props.dispatch.tour.goToStep}
+            onCancel={this.props.dispatch.tour.end}
+            onNext={this.props.dispatch.tour.goToStep}
             ref="tour"
             step={this.props.tour.step}
             steps={this.props.tour.steps}
           />
         </div>
-        <UserTourErrorMessage error={this.props.tour.error} onDismiss={this.props.actions.tour.end}/>
+        <UserTourErrorMessage error={this.props.tour.error} onDismiss={this.props.dispatch.tour.end}/>
       </div>
     )
   }
@@ -653,7 +653,7 @@ export class UserTour extends React.Component<Props> {
       return Promise.resolve(loc.pathname)
     } else {
       return new Promise((resolve, reject) => {
-        this.props.actions.route.navigateTo({ loc })
+        this.props.dispatch.route.navigateTo({ loc })
 
         const timeout = 30000
         const t0 = Date.now()
@@ -684,7 +684,7 @@ export class UserTour extends React.Component<Props> {
         break
       }
       case 'Escape': {
-        this.props.actions.tour.end()
+        this.props.dispatch.tour.end()
 
         break
       }
@@ -770,30 +770,30 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    actions: {
+    dispatch: {
       catalog: {
-        resetSearchCriteria: () => dispatch(catalogActions.resetSearchCriteria()),
+        resetSearchCriteria: () => dispatch(Catalog.resetSearchCriteria()),
         updateSearchCriteria: (args: CatalogUpdateSearchCriteriaArgs) => (
-          dispatch(catalogActions.updateSearchCriteria(args))
+          dispatch(Catalog.updateSearchCriteria(args))
         ),
-        setApiKey: (apiKey: string) => dispatch(catalogActions.setApiKey(apiKey)),
-        serialize: () => dispatch(catalogActions.serialize()),
+        setApiKey: (apiKey: string) => dispatch(Catalog.setApiKey(apiKey)),
+        serialize: () => dispatch(Catalog.serialize()),
       },
       map: {
-        panToPoint: (args: MapPanToPointArgs) => dispatch(mapActions.panToPoint(args)),
-        updateBbox: (bbox: Extent) => dispatch(mapActions.updateBbox(bbox)),
-        clearBbox: () => dispatch(mapActions.clearBbox()),
+        panToPoint: (args: { point: Point, zoom?: number }) => dispatch(Map.panToPoint(args)),
+        updateBbox: (bbox: Extent) => dispatch(Map.updateBbox(bbox)),
+        clearBbox: () => dispatch(Map.clearBbox()),
         setSelectedFeature: (feature: GeoJSON.Feature<any> | null) => (
-          dispatch(mapActions.setSelectedFeature(feature))
+          dispatch(Map.setSelectedFeature(feature))
         ),
       },
       route: {
-        navigateTo: (args: RouteNavigateToArgs) => dispatch(routeActions.navigateTo(args)),
+        navigateTo: (args: RouteNavigateToArgs) => dispatch(Route.navigateTo(args)),
       },
       tour: {
-        setSteps: (steps: TourStep[]) => dispatch(tourActions.setSteps(steps)),
-        end: () => dispatch(tourActions.end()),
-        goToStep: (step: number) => dispatch(tourActions.goToStep(step)),
+        setSteps: (steps: TourStep[]) => dispatch(Tour.setSteps(steps)),
+        end: () => dispatch(Tour.end()),
+        goToStep: (step: number) => dispatch(Tour.goToStep(step)),
       },
     },
   }

--- a/src/reducers/algorithmsReducer.ts
+++ b/src/reducers/algorithmsReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {algorithmsTypes} from '../actions/algorithmsActions'
+import {Action} from 'redux'
+import {AlgorithmsActions as Actions} from '../actions/algorithmsActions'
 
 export interface AlgorithmsState {
   records: beachfront.Algorithm[]
@@ -28,31 +29,37 @@ export const algorithmsInitialState: AlgorithmsState = {
   fetchError: null,
 }
 
-export function algorithmsReducer(state = algorithmsInitialState, action: any) {
+export function algorithmsReducer(state = algorithmsInitialState, action: Action): AlgorithmsState {
   switch (action.type) {
-    case algorithmsTypes.ALGORITHMS_DESERIALIZED:
-      return {
-        ...state,
-        ...action.deserialized,
-      }
-    case algorithmsTypes.ALGORITHMS_FETCHING:
+    case Actions.Fetching.type:
       return {
         ...state,
         isFetching: true,
         fetchError: null,
       }
-    case algorithmsTypes.ALGORITHMS_FETCH_SUCCESS:
+    case Actions.FetchSuccess.type: {
+      const payload = (action as Actions.FetchSuccess).payload
       return {
         ...state,
         isFetching: false,
-        records: action.records,
+        records: payload.records,
       }
-    case algorithmsTypes.ALGORITHMS_FETCH_ERROR:
+    }
+    case Actions.FetchError.type: {
+      const payload = (action as Actions.FetchError).payload
       return {
         ...state,
         isFetching: false,
-        fetchError: action.error,
+        fetchError: payload.error,
       }
+    }
+    case Actions.Deserialized.type: {
+      const payload = (action as Actions.Deserialized).payload
+      return {
+        ...state,
+        records: payload.records,
+      }
+    }
     default:
       return state
   }

--- a/src/reducers/apiStatusReducer.ts
+++ b/src/reducers/apiStatusReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {apiStatusTypes} from '../actions/apiStatusActions'
+import {ApiStatusActions as Actions} from '../actions/apiStatusActions'
+import {Action} from 'redux'
 
 export interface ApiStatusState {
   geoserver: {
@@ -34,32 +35,39 @@ export const apiStatusInitialState: ApiStatusState = {
   fetchError: null,
 }
 
-export function apiStatusReducer(state = apiStatusInitialState, action: any) {
+export function apiStatusReducer(state = apiStatusInitialState, action: Action): ApiStatusState {
   switch (action.type) {
-    case apiStatusTypes.API_STATUS_DESERIALIZED:
-      return {
-        ...state,
-        ...action.deserialized,
-      }
-    case apiStatusTypes.API_STATUS_FETCHING:
+    case Actions.Fetching.type:
       return {
         ...state,
         isFetching: true,
         fetchError: null,
       }
-    case apiStatusTypes.API_STATUS_FETCH_SUCCESS:
+    case Actions.FetchSuccess.type: {
+      const payload = (action as Actions.FetchSuccess).payload
       return {
         ...state,
         isFetching: false,
-        geoserver: action.geoserver,
-        enabledPlatforms: action.enabledPlatforms,
+        geoserver: payload.geoserver,
+        enabledPlatforms: payload.enabledPlatforms,
       }
-    case apiStatusTypes.API_STATUS_FETCH_ERROR:
+    }
+    case Actions.FetchError.type: {
+      const payload = (action as Actions.FetchError).payload
       return {
         ...state,
         isFetching: false,
-        fetchError: action.error,
+        fetchError: payload.error,
       }
+    }
+    case Actions.Deserialized.type: {
+      const payload = (action as Actions.Deserialized).payload
+      return {
+        ...state,
+        geoserver: payload.geoserver,
+        enabledPlatforms: payload.enabledPlatforms,
+      }
+    }
     default:
       return state
   }

--- a/src/reducers/catalogReducer.ts
+++ b/src/reducers/catalogReducer.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  **/
 
-import {catalogTypes} from '../actions/catalogActions'
-import {mapTypes} from '../actions/mapActions'
+import {Action} from 'redux'
+import {CatalogActions as Actions} from '../actions/catalogActions'
+import {MapActions} from '../actions/mapActions'
 import * as moment from 'moment'
 import {SOURCE_DEFAULT} from '../constants'
 
@@ -47,50 +48,62 @@ export const catalogInitialState: CatalogState = {
   searchResults: null,
 }
 
-export function catalogReducer(state = catalogInitialState, action: any): CatalogState {
+export function catalogReducer(state = catalogInitialState, action: Action): CatalogState {
   switch (action.type) {
-    case catalogTypes.CATALOG_DESERIALIZED:
+    case Actions.ApiKeyUpdated.type: {
+      const payload = (action as Actions.ApiKeyUpdated).payload
       return {
         ...state,
-        ...action.deserialized,
+        apiKey: payload.apiKey,
       }
-    case catalogTypes.CATALOG_API_KEY_UPDATED:
-      return {
-        ...state,
-        apiKey: action.apiKey,
-      }
-    case catalogTypes.CATALOG_SEARCH_CRITERIA_UPDATED:
+    }
+    case Actions.SearchCriteriaUpdated.type: {
+      const payload = (action as Actions.SearchCriteriaUpdated).payload
       return {
         ...state,
         searchCriteria: {
           ...state.searchCriteria,
-          ...action.searchCriteria,
+          ...payload.searchCriteria,
         },
       }
-    case catalogTypes.CATALOG_SEARCH_CRITERIA_RESET:
+    }
+    case Actions.SearchCriteriaReset.type:
       return {
         ...state,
         searchCriteria: catalogInitialState.searchCriteria,
       }
-    case catalogTypes.CATALOG_SEARCHING:
+    case Actions.Searching.type:
       return {
         ...state,
         isSearching: true,
         searchError: null,
       }
-    case catalogTypes.CATALOG_SEARCH_SUCCESS:
+    case Actions.SearchSuccess.type: {
+      const payload = (action as Actions.SearchSuccess).payload
       return {
         ...state,
         isSearching: false,
-        searchResults: action.searchResults,
+        searchResults: payload.searchResults,
       }
-    case catalogTypes.CATALOG_SEARCH_ERROR:
+    }
+    case Actions.SearchError.type: {
+      const payload = (action as Actions.SearchError).payload
       return {
         ...state,
         isSearching: false,
-        searchError: action.error,
+        searchError: payload.error,
       }
-    case mapTypes.MAP_BBOX_CLEARED:
+    }
+    case Actions.Deserialized.type: {
+      const payload = (action as Actions.Deserialized).payload
+      return {
+        ...state,
+        searchCriteria: payload.searchCriteria,
+        searchResults: payload.searchResults,
+        apiKey: payload.apiKey,
+      }
+    }
+    case MapActions.BboxCleared.type:
       return {
         ...state,
         searchResults: null,

--- a/src/reducers/jobsReducer.ts
+++ b/src/reducers/jobsReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {jobsTypes} from '../actions/jobsActions'
+import {Action} from 'redux'
+import {JobsActions as Actions} from '../actions/jobsActions'
 
 export type JobsState = {
   records: beachfront.Job[]
@@ -48,91 +49,107 @@ export const jobsInitialState: JobsState = {
   createJobError: null,
 }
 
-export function jobsReducer(state = jobsInitialState, action: any) {
+export function jobsReducer(state = jobsInitialState, action: Action): JobsState {
   switch (action.type) {
-    case jobsTypes.JOBS_FETCHING:
+    case Actions.Fetching.type:
       return {
         ...state,
         isFetching: true,
         fetchError: null,
       }
-    case jobsTypes.JOBS_FETCH_SUCCESS:
+    case Actions.FetchSuccess.type: {
+      const payload = (action as Actions.FetchSuccess).payload
       return {
         ...state,
         isFetching: false,
-        records: action.records,
+        records: payload.records,
         initialFetchComplete: true,
       }
-    case jobsTypes.JOBS_FETCH_ERROR:
+    }
+    case Actions.FetchError.type: {
+      const payload = (action as Actions.FetchError).payload
       return {
         ...state,
         isFetching: false,
-        fetchError: action.error,
+        fetchError: payload.error,
       }
-    case jobsTypes.JOBS_FETCHING_ONE:
+    }
+    case Actions.FetchingOne.type:
       return {
         ...state,
         isFetchingOne: true,
         fetchOneError: null,
       }
-    case jobsTypes.JOBS_FETCH_ONE_SUCCESS:
+    case Actions.FetchOneSuccess.type: {
+      const payload = (action as Actions.FetchOneSuccess).payload
       return {
         ...state,
         isFetchingOne: false,
-        records: [...state.records, action.record],
-        lastOneFetched: action.record,
+        records: [...state.records, payload.record],
+        lastOneFetched: payload.record,
       }
-    case jobsTypes.JOBS_FETCH_ONE_ERROR:
+    }
+    case Actions.FetchOneError.type: {
+      const payload = (action as Actions.FetchOneError).payload
       return {
         ...state,
         isFetchingOne: false,
-        fetchOneError: action.error,
+        fetchOneError: payload.error,
       }
-    case jobsTypes.JOBS_CREATING_JOB:
+    }
+    case Actions.CreatingJob.type:
       return {
         ...state,
         isCreatingJob: true,
         createdJob: null,
         createJobError: null,
       }
-    case jobsTypes.JOBS_CREATE_JOB_SUCCESS:
+    case Actions.CreateJobSuccess.type: {
+      const payload = (action as Actions.CreateJobSuccess).payload
       return {
         ...state,
         isCreatingJob: false,
-        createdJob: action.createdJob,
-        records: [...state.records, action.createdJob],
+        createdJob: payload.createdJob,
+        records: [...state.records, payload.createdJob],
       }
-    case jobsTypes.JOBS_CREATE_JOB_ERROR:
+    }
+    case Actions.CreateJobError.type: {
+      const payload = (action as Actions.CreateJobError).payload
       return {
         ...state,
         isCreatingJob: false,
-        createJobError: action.error,
+        createJobError: payload.error,
       }
-    case jobsTypes.JOBS_CREATE_JOB_ERROR_DISMISSED:
+    }
+    case Actions.CreateJobErrorDismissed.type:
       return {
         ...state,
         createJobError: null,
       }
-    case jobsTypes.JOBS_DELETING_JOB:
+    case Actions.DeletingJob.type: {
+      const payload = (action as Actions.DeletingJob).payload
       return {
         ...state,
-        records: state.records.filter(job => job.id !== action.deletedJob.id),
+        records: state.records.filter(job => job.id !== payload.deletedJob.id),
         isDeletingJob: true,
-        deletedJob: action.deletedJob,
+        deletedJob: payload.deletedJob,
         deleteJobError: null,
       }
-    case jobsTypes.JOBS_DELETE_JOB_SUCCESS:
+    }
+    case Actions.DeleteJobSuccess.type:
       return {
         ...state,
         isDeletingJob: false,
       }
-    case jobsTypes.JOBS_DELETE_JOB_ERROR:
+    case Actions.DeleteJobError.type: {
+      const payload = (action as Actions.DeleteJobError).payload
       return {
         ...state,
-        records: [...state.records, state.deletedJob],
+        records: [...state.records, state.deletedJob!],
         isDeletingJob: false,
-        deleteJobError: action.error,
+        deleteJobError: payload.error,
       }
+    }
     default:
       return state
   }

--- a/src/reducers/mapReducer.ts
+++ b/src/reducers/mapReducer.ts
@@ -14,18 +14,12 @@
  * limitations under the License.
  **/
 
-import {mapTypes} from '../actions/mapActions'
+import {MapActions as Actions} from '../actions/mapActions'
 import {MapView, MODE_NORMAL} from '../components/PrimaryMap'
 import {TYPE_JOB} from '../constants'
 import {shouldSelectedFeatureAutoDeselect} from '../utils/mapUtils'
 import {Extent} from '../utils/geometries'
-
-// {
-//   hovered: this.hoverInteraction.getFeatures(),
-//     imagery: this.imageryLayer.getSource().getFeaturesCollection(),
-//   selected: this.selectInteraction.getFeatures(),
-//   handleSelectFeature: this.handleSelectFeature,
-// }
+import {Action} from 'redux'
 
 export interface MapCollections {
   hovered: ol.Collection<ol.Feature>
@@ -58,30 +52,31 @@ export const mapInitialState: MapState = {
   selectedFeature: null,
 }
 
-export function mapReducer(state = mapInitialState, action: any) {
+export function mapReducer(state = mapInitialState, action: Action): MapState {
   switch (action.type) {
-    case mapTypes.MAP_INITIALIZED:
+    case Actions.Initialized.type: {
+      const payload = (action as Actions.Initialized).payload
       return {
         ...state,
-        map: action.map,
-        collections: action.collections,
+        map: payload.map,
+        collections: payload.collections,
       }
-    case mapTypes.MAP_DESERIALIZED:
+    }
+    case Actions.ModeUpdated.type: {
+      const payload = (action as Actions.ModeUpdated).payload
       return {
         ...state,
-        ...action.deserialized,
+        mode: payload.mode,
       }
-    case mapTypes.MAP_MODE_UPDATED:
+    }
+    case Actions.BboxUpdated.type: {
+      const payload = (action as Actions.BboxUpdated).payload
       return {
         ...state,
-        mode: action.mode,
+        bbox: payload.bbox,
       }
-    case mapTypes.MAP_BBOX_UPDATED:
-      return {
-        ...state,
-        bbox: action.bbox,
-      }
-    case mapTypes.MAP_BBOX_CLEARED: {
+    }
+    case Actions.BboxCleared.type: {
       let selectedFeature = state.selectedFeature
       if (shouldSelectedFeatureAutoDeselect(selectedFeature, { ignoreTypes: [TYPE_JOB] })) {
         selectedFeature = null
@@ -90,56 +85,76 @@ export function mapReducer(state = mapInitialState, action: any) {
       return {
         ...state,
         bbox: null,
-        searchResults: null,
-        searchError: null,
         selectedFeature,
       }
     }
-    case mapTypes.MAP_DETECTIONS_UPDATED:
+    case Actions.DetectionsUpdated.type: {
+      const payload = (action as Actions.DetectionsUpdated).payload
       return {
         ...state,
-        detections: action.detections,
+        detections: payload.detections,
       }
-    case mapTypes.MAP_FRAMES_UPDATED:
+    }
+    case Actions.FramesUpdated.type: {
+      const payload = (action as Actions.FramesUpdated).payload
       return {
         ...state,
-        frames: action.frames,
+        frames: payload.frames,
       }
-    case mapTypes.MAP_SELECTED_FEATURE_UPDATED:
+    }
+    case Actions.SelectedFeatureUpdated.type: {
+      const payload = (action as Actions.SelectedFeatureUpdated).payload
       return {
         ...state,
-        selectedFeature: action.selectedFeature,
+        selectedFeature: payload.selectedFeature,
       }
-    case mapTypes.MAP_HOVERED_FEATURE_UPDATED:
+    }
+    case Actions.HoveredFeatureUpdated.type: {
+      const payload = (action as Actions.HoveredFeatureUpdated).payload
       return {
         ...state,
-        hoveredFeature: action.hoveredFeature,
+        hoveredFeature: payload.hoveredFeature,
       }
-    case mapTypes.MAP_VIEW_UPDATED:
+    }
+    case Actions.ViewUpdated.type: {
+      const payload = (action as Actions.ViewUpdated).payload
       return {
         ...state,
-        view: action.view,
+        view: payload.view,
       }
-    case mapTypes.MAP_PAN_TO_POINT:
+    }
+    case Actions.PanToPoint.type: {
+      const payload = (action as Actions.PanToPoint).payload
       return {
         ...state,
         view: {
-          ...state.view,
-          center: action.point,
-          zoom: action.zoom,
+          ...state.view!,
+          center: payload.point,
+          zoom: payload.zoom,
           extent: null,
         },
       }
-    case mapTypes.MAP_PAN_TO_EXTENT:
+    }
+    case Actions.PanToExtent.type: {
+      const payload = (action as Actions.PanToExtent).payload
       return {
         ...state,
         view: {
-          ...state.view,
-          extent: action.extent,
+          ...state.view!,
+          extent: payload.extent,
           center: null,
           zoom: null,
         },
       }
+    }
+    case Actions.Deserialized.type: {
+      const payload = (action as Actions.Deserialized).payload
+      return {
+        ...state,
+        bbox: payload.bbox,
+        view: payload.view,
+      }
+    }
     default:
       return state
   }

--- a/src/reducers/productLinesReducer.ts
+++ b/src/reducers/productLinesReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {productLinesTypes} from '../actions/productLinesActions'
+import {Action} from 'redux'
+import {ProductLinesActions as Actions} from '../actions/productLinesActions'
 
 export interface ProductLinesState {
   records: beachfront.ProductLine[]
@@ -40,64 +41,76 @@ export const productLinesInitialState: ProductLinesState = {
   createProductLineError: null,
 }
 
-export function productLinesReducer(state = productLinesInitialState, action: any) {
+export function productLinesReducer(state = productLinesInitialState, action: Action): ProductLinesState {
   switch (action.type) {
-    case productLinesTypes.PRODUCT_LINES_FETCHING:
+    case Actions.Fetching.type:
       return {
         ...state,
         isFetching: true,
         fetchError: null,
       }
-    case productLinesTypes.PRODUCT_LINES_FETCH_SUCCESS:
+    case Actions.FetchSuccess.type: {
+      const payload = (action as Actions.FetchSuccess).payload
       return {
         ...state,
         isFetching: false,
-        records: action.records,
+        records: payload.records,
       }
-    case productLinesTypes.PRODUCT_LINES_FETCH_ERROR:
+    }
+    case Actions.FetchError.type: {
+      const payload = (action as Actions.FetchError).payload
       return {
         ...state,
         isFetching: false,
-        fetchError: action.error,
+        fetchError: payload.error,
       }
-    case productLinesTypes.PRODUCT_LINES_FETCHING_JOBS:
+    }
+    case Actions.FetchingJobs.type:
       return {
         ...state,
         isFetchingJobs: true,
         fetchJobsError: null,
       }
-    case productLinesTypes.PRODUCT_LINES_FETCH_JOBS_SUCCESS:
+    case Actions.FetchJobsSuccess.type: {
+      const payload = (action as Actions.FetchJobsSuccess).payload
       return {
         ...state,
         isFetchingJobs: false,
-        jobs: action.jobs,
+        jobs: payload.jobs,
       }
-    case productLinesTypes.PRODUCT_LINES_FETCH_JOBS_ERROR:
+    }
+    case Actions.FetchJobsError.type: {
+      const payload = (action as Actions.FetchJobsError).payload
       return {
         ...state,
         isFetchingJobs: false,
-        fetchJobsError: action.error,
+        fetchJobsError: payload.error,
       }
-    case productLinesTypes.PRODUCT_LINES_CREATING_PRODUCT_LINE:
+    }
+    case Actions.CreatingProductLine.type:
       return {
         ...state,
         isCreatingProductLine: true,
         createdProductLine: null,
         createProductLineError: null,
       }
-    case productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_SUCCESS:
+    case Actions.CreateProductLineSuccess.type: {
+      const payload = (action as Actions.CreateProductLineSuccess).payload
       return {
         ...state,
         isCreatingProductLine: false,
-        createdProductLine: action.createdProductLine,
-        records: [...state.records, action.createdProductLine],
+        createdProductLine: payload.createdProductLine,
+        records: [...state.records, payload.createdProductLine],
       }
-    case productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_ERROR:
+    }
+    case Actions.CreateProductLineError.type: {
+      const payload = (action as Actions.CreateProductLineError).payload
       return {
         ...state,
         isCreatingProductLine: false,
-        createProductLineError: action.error,
+        createProductLineError: payload.error,
       }
+    }
     default:
       return state
   }

--- a/src/reducers/routeReducer.ts
+++ b/src/reducers/routeReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {routeTypes} from '../actions/routeActions'
+import {Action} from 'redux'
+import {RouteActions as Actions} from '../actions/routeActions'
 import {generateRoute} from '../utils/routeUtils'
 
 export interface RouteState {
@@ -28,18 +29,20 @@ export interface RouteState {
 
 export const routeInitialState: RouteState = generateRoute(location)
 
-export function routeReducer(state = routeInitialState, action: any): RouteState {
+export function routeReducer(state = routeInitialState, action: Action): RouteState {
   switch (action.type) {
-    case routeTypes.ROUTE_CHANGED:
+    case Actions.Changed.type: {
+      const payload = (action as Actions.Changed).payload
       return {
         ...state,
-        hash: action.hash,
-        href: action.href,
-        jobIds: action.jobIds,
-        pathname: action.pathname,
-        search: action.search,
-        selectedFeature: action.selectedFeature,
+        hash: payload.hash,
+        href: payload.href,
+        jobIds: payload.jobIds,
+        pathname: payload.pathname,
+        search: payload.search,
+        selectedFeature: payload.selectedFeature,
       }
+    }
     default:
       return state
   }

--- a/src/reducers/tourReducer.ts
+++ b/src/reducers/tourReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {TourStep, tourTypes} from '../actions/tourActions'
+import {Action} from 'redux'
+import {TourActions as Actions, TourStep} from '../actions/tourActions'
 
 export interface TourState {
   inProgress: boolean
@@ -32,14 +33,16 @@ export const tourInitialState: TourState = {
   steps: [],
 }
 
-export function tourReducer(state = tourInitialState, action: any) {
+export function tourReducer(state = tourInitialState, action: Action): TourState {
   switch (action.type) {
-    case tourTypes.TOUR_STEPS_UPDATED:
+    case Actions.StepsUpdated.type: {
+      const payload = (action as Actions.StepsUpdated).payload
       return {
         ...state,
-        steps: action.steps,
+        steps: payload.steps,
       }
-    case tourTypes.TOUR_STARTED:
+    }
+    case Actions.Started.type:
       return {
         ...state,
         inProgress: true,
@@ -47,30 +50,34 @@ export function tourReducer(state = tourInitialState, action: any) {
         step: 1,
         error: null,
       }
-    case tourTypes.TOUR_ENDED:
+    case Actions.Ended.type:
       return {
         ...state,
         inProgress: false,
         changing: false,
         error: null,
       }
-    case tourTypes.TOUR_STEP_CHANGING:
+    case Actions.StepChanging.type:
       return {
         ...state,
         changing: true,
       }
-    case tourTypes.TOUR_STEP_CHANGE_SUCCESS:
+    case Actions.StepChangeSuccess.type: {
+      const payload = (action as Actions.StepChangeSuccess).payload
       return {
         ...state,
         changing: false,
-        step: action.step,
+        step: payload.step,
       }
-    case tourTypes.TOUR_STEP_CHANGE_ERROR:
+    }
+    case Actions.StepChangeError.type: {
+      const payload = (action as Actions.StepChangeError).payload
       return {
         ...state,
         changing: false,
-        error: action.error,
+        error: payload.error,
       }
+    }
     default:
       return state
   }

--- a/src/reducers/userReducer.ts
+++ b/src/reducers/userReducer.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  **/
 
-import {userTypes} from '../actions/userActions'
+import {Action} from 'redux'
+import {UserActions as Actions} from '../actions/userActions'
 import * as session from '../api/session'
 
 export interface UserState {
@@ -31,36 +32,38 @@ export const userInitialState: UserState = {
   catalogApiKey: '',
 }
 
-export function userReducer(state = userInitialState, action: any): UserState {
+export function userReducer(state = userInitialState, action: Action): UserState {
   switch (action.type) {
-    case userTypes.USER_DESERIALIZED:
-      return {
-        ...state,
-        ...action.deserialized,
-      }
-    case userTypes.USER_LOGGED_OUT:
+    case Actions.LoggedOut.type:
       return {
         ...state,
         isLoggedIn: false,
         isSessionLoggedOut: true,
       }
-    case userTypes.USER_SESSION_CLEARED:
+    case Actions.SessionCleared.type:
       return {
         ...state,
         isLoggedIn: false,
         isSessionExpired: false,
       }
-    case userTypes.USER_SESSION_LOGGED_OUT:
+    case Actions.SessionLoggedOut.type:
       return {
         ...state,
         isLoggedIn: false,
         isSessionLoggedOut: false,
       }
-    case userTypes.USER_SESSION_EXPIRED:
+    case Actions.SessionExpired.type:
       return {
         ...state,
         isSessionExpired: true,
       }
+    case Actions.Deserialized.type: {
+      const payload = (action as Actions.Deserialized).payload
+      return {
+        ...state,
+        isSessionExpired: payload.isSessionExpired,
+      }
+    }
     default:
       return state
   }

--- a/test/actions/actionTypes.test.ts
+++ b/test/actions/actionTypes.test.ts
@@ -14,28 +14,36 @@
  * limitations under the License.
  */
 
-import {algorithmsTypes} from '../../src/actions/algorithmsActions'
-import {apiStatusTypes} from '../../src/actions/apiStatusActions'
-import {catalogTypes} from '../../src/actions/catalogActions'
-import {jobsTypes} from '../../src/actions/jobsActions'
-import {mapTypes} from '../../src/actions/mapActions'
-import {productLinesTypes} from '../../src/actions/productLinesActions'
-import {routeTypes} from '../../src/actions/routeActions'
-import {tourTypes} from '../../src/actions/tourActions'
-import {userTypes} from '../../src/actions/userActions'
+import {AlgorithmsActions} from '../../src/actions/algorithmsActions'
+import {ApiStatusActions} from '../../src/actions/apiStatusActions'
+import {CatalogActions} from '../../src/actions/catalogActions'
+import {JobsActions} from '../../src/actions/jobsActions'
+import {MapActions} from '../../src/actions/mapActions'
+import {ProductLinesActions} from '../../src/actions/productLinesActions'
+import {RouteActions} from '../../src/actions/routeActions'
+import {TourActions} from '../../src/actions/tourActions'
+import {UserActions} from '../../src/actions/userActions'
+
+const ActionsGroups = [
+  AlgorithmsActions,
+  ApiStatusActions,
+  CatalogActions,
+  JobsActions,
+  MapActions,
+  ProductLinesActions,
+  RouteActions,
+  TourActions,
+  UserActions,
+]
 
 describe('action types', () => {
   test('no duplicate types', () => {
     const allTypes: string[] = []
-    Object.keys(algorithmsTypes).forEach(key => allTypes.push((<any>algorithmsTypes)[key]))
-    Object.keys(apiStatusTypes).forEach(key => allTypes.push((<any>apiStatusTypes)[key]))
-    Object.keys(catalogTypes).forEach(key => allTypes.push((<any>catalogTypes)[key]))
-    Object.keys(jobsTypes).forEach(key => allTypes.push((<any>jobsTypes)[key]))
-    Object.keys(mapTypes).forEach(key => allTypes.push((<any>mapTypes)[key]))
-    Object.keys(productLinesTypes).forEach(key => allTypes.push((<any>productLinesTypes)[key]))
-    Object.keys(routeTypes).forEach(key => allTypes.push((<any>routeTypes)[key]))
-    Object.keys(tourTypes).forEach(key => allTypes.push((<any>tourTypes)[key]))
-    Object.keys(userTypes).forEach(key => allTypes.push((<any>userTypes)[key]))
+    ActionsGroups.map(actionsGroup => {
+      Object.keys(actionsGroup).forEach(key => {
+        allTypes.push((actionsGroup as any)[key].type)
+      })
+    })
     allTypes.sort()
 
     allTypes.forEach((value: any, index: number) => {
@@ -47,27 +55,34 @@ describe('action types', () => {
     })
   })
 
-  test('keys match values', () => {
-    Object.keys(algorithmsTypes).forEach(key => expect(key).toEqual((<any>algorithmsTypes)[key]))
-    Object.keys(apiStatusTypes).forEach(key => expect(key).toEqual((<any>apiStatusTypes)[key]))
-    Object.keys(catalogTypes).forEach(key => expect(key).toEqual((<any>catalogTypes)[key]))
-    Object.keys(jobsTypes).forEach(key => expect(key).toEqual((<any>jobsTypes)[key]))
-    Object.keys(mapTypes).forEach(key => expect(key).toEqual((<any>mapTypes)[key]))
-    Object.keys(productLinesTypes).forEach(key => expect(key).toEqual((<any>productLinesTypes)[key]))
-    Object.keys(routeTypes).forEach(key => expect(key).toEqual((<any>routeTypes)[key]))
-    Object.keys(tourTypes).forEach(key => expect(key).toEqual((<any>tourTypes)[key]))
-    Object.keys(userTypes).forEach(key => expect(key).toEqual((<any>userTypes)[key]))
+  test('static types match instance types', () => {
+    ActionsGroups.map(actionsGroup => {
+      Object.keys(actionsGroup).forEach(key => {
+        const actionClass = (actionsGroup as any)[key]
+        const action = new actionClass({})
+        expect(actionClass.type).toEqual(action.type)
+      })
+    })
   })
 
   test('correct prefixes', () => {
-    Object.keys(algorithmsTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^ALGORITHMS_/)))
-    Object.keys(apiStatusTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^API_STATUS_/)))
-    Object.keys(catalogTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^CATALOG_/)))
-    Object.keys(jobsTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^JOBS_/)))
-    Object.keys(mapTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^MAP_/)))
-    Object.keys(productLinesTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^PRODUCT_LINES_/)))
-    Object.keys(routeTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^ROUTE_/)))
-    Object.keys(tourTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^TOUR_/)))
-    Object.keys(userTypes).forEach(key => expect(key).toEqual(expect.stringMatching(/^USER_/)))
+    const expectedPrefixes = [
+      { group: AlgorithmsActions, prefix: 'ALGORITHMS' },
+      { group: ApiStatusActions, prefix: 'API_STATUS' },
+      { group: CatalogActions, prefix: 'CATALOG' },
+      { group: JobsActions, prefix: 'JOBS' },
+      { group: MapActions, prefix: 'MAP' },
+      { group: ProductLinesActions, prefix: 'PRODUCT_LINES' },
+      { group: RouteActions, prefix: 'ROUTE' },
+      { group: TourActions, prefix: 'TOUR' },
+      { group: UserActions, prefix: 'USER' },
+    ]
+
+    expectedPrefixes.map(expected => {
+      Object.keys(expected.group).forEach(key => {
+        const actionClass = (expected.group as any)[key]
+        expect(actionClass.type).toEqual(expect.stringMatching(new RegExp(`^${expected.prefix}_`)))
+      })
+    })
   })
 })

--- a/test/actions/jobsActions.test.ts
+++ b/test/actions/jobsActions.test.ts
@@ -20,7 +20,7 @@ import thunk from 'redux-thunk'
 import configureStore, {MockStoreEnhanced} from 'redux-mock-store'
 import * as sinon from 'sinon'
 import {SinonSpy} from 'sinon'
-import {jobsActions, jobsTypes} from '../../src/actions/jobsActions'
+import {Jobs, JobsActions} from '../../src/actions/jobsActions'
 import {JOB_ENDPOINT} from '../../src/config'
 import {getClient} from '../../src/api/session'
 import {AppState, initialState} from '../../src/store'
@@ -60,16 +60,18 @@ describe('jobsActions', () => {
       }
       mockAdapter.onGet(JOB_ENDPOINT).reply(200, mockResponseData)
 
-      await store.dispatch(jobsActions.fetch() as any)
+      await store.dispatch(Jobs.fetch() as any)
 
       expect(clientSpies.get.callCount).toEqual(1)
       expect(clientSpies.get.args[0]).toEqual([JOB_ENDPOINT])
 
       expect(store.getActions()).toEqual([
-        { type: jobsTypes.JOBS_FETCHING },
+        { type: JobsActions.Fetching.type },
         {
-          type: jobsTypes.JOBS_FETCH_SUCCESS,
-          records: mockResponseData.jobs.features,
+          type: JobsActions.FetchSuccess.type,
+          payload: {
+            records: mockResponseData.jobs.features,
+          },
         },
       ])
     })
@@ -77,25 +79,25 @@ describe('jobsActions', () => {
     test('request error', async () => {
       mockAdapter.onGet(JOB_ENDPOINT).reply(400)
 
-      await store.dispatch(jobsActions.fetch() as any)
+      await store.dispatch(Jobs.fetch() as any)
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: jobsTypes.JOBS_FETCHING })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_FETCH_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: JobsActions.Fetching.type })
+      expect(actions[1].type).toEqual(JobsActions.FetchError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('invalid response data', async () => {
       mockAdapter.onGet(JOB_ENDPOINT).reply(200)
 
-      await store.dispatch(jobsActions.fetch() as any)
+      await store.dispatch(Jobs.fetch() as any)
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: jobsTypes.JOBS_FETCHING })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_FETCH_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: JobsActions.Fetching.type })
+      expect(actions[1].type).toEqual(JobsActions.FetchError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 
@@ -108,16 +110,18 @@ describe('jobsActions', () => {
       const url = `${JOB_ENDPOINT}/${mockJobId}`
       mockAdapter.onGet(url).reply(200, mockResponseData)
 
-      await store.dispatch(jobsActions.fetchOne(mockJobId) as any)
+      await store.dispatch(Jobs.fetchOne(mockJobId) as any)
 
       expect(clientSpies.get.callCount).toEqual(1)
       expect(clientSpies.get.args[0]).toEqual([url])
 
       expect(store.getActions()).toEqual([
-        { type: jobsTypes.JOBS_FETCHING_ONE },
+        { type: JobsActions.FetchingOne.type },
         {
-          type: jobsTypes.JOBS_FETCH_ONE_SUCCESS,
-          record: mockResponseData.job,
+          type: JobsActions.FetchOneSuccess.type,
+          payload: {
+            record: mockResponseData.job,
+          },
         },
       ])
     })
@@ -126,26 +130,26 @@ describe('jobsActions', () => {
       const mockJobId = 'a'
       mockAdapter.onGet(`${JOB_ENDPOINT}/${mockJobId}`).reply(400)
 
-      await store.dispatch(jobsActions.fetchOne(mockJobId) as any)
+      await store.dispatch(Jobs.fetchOne(mockJobId) as any)
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: jobsTypes.JOBS_FETCHING_ONE })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_FETCH_ONE_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: JobsActions.FetchingOne.type })
+      expect(actions[1].type).toEqual(JobsActions.FetchOneError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('invalid response data', async () => {
       const mockJob = { id: 'a' }
       mockAdapter.onGet(`${JOB_ENDPOINT}/${mockJob.id}`).reply(200)
 
-      await store.dispatch(jobsActions.fetchOne(mockJob.id) as any)
+      await store.dispatch(Jobs.fetchOne(mockJob.id) as any)
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: jobsTypes.JOBS_FETCHING_ONE })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_FETCH_ONE_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: JobsActions.FetchingOne.type })
+      expect(actions[1].type).toEqual(JobsActions.FetchOneError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 
@@ -163,7 +167,7 @@ describe('jobsActions', () => {
         catalogApiKey: 'catalogApiKey',
         sceneId: 'sceneId',
       }
-      await store.dispatch(jobsActions.createJob(args) as any)
+      await store.dispatch(Jobs.createJob(args) as any)
 
       expect(clientSpies.post.callCount).toEqual(1)
       expect(clientSpies.post.args[0]).toEqual([
@@ -178,10 +182,12 @@ describe('jobsActions', () => {
       ])
 
       expect(store.getActions()).toEqual([
-        { type: jobsTypes.JOBS_CREATING_JOB },
+        { type: JobsActions.CreatingJob.type },
         {
-          type: jobsTypes.JOBS_CREATE_JOB_SUCCESS,
-          createdJob: mockResponseData.job,
+          type: JobsActions.CreateJobSuccess.type,
+          payload: {
+            createdJob: mockResponseData.job,
+          },
         },
       ])
     })
@@ -189,7 +195,7 @@ describe('jobsActions', () => {
     test('request error', async () => {
       mockAdapter.onPost(JOB_ENDPOINT).reply(400)
 
-      await store.dispatch(jobsActions.createJob({
+      await store.dispatch(Jobs.createJob({
         algorithmId: 'algorithmId',
         computeMask: true,
         name: 'name',
@@ -199,15 +205,15 @@ describe('jobsActions', () => {
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: jobsTypes.JOBS_CREATING_JOB })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_CREATE_JOB_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: JobsActions.CreatingJob.type })
+      expect(actions[1].type).toEqual(JobsActions.CreateJobError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('invalid response data', async () => {
       mockAdapter.onPost(JOB_ENDPOINT).reply(200)
 
-      await store.dispatch(jobsActions.createJob({
+      await store.dispatch(Jobs.createJob({
         algorithmId: 'algorithmId',
         computeMask: true,
         name: 'name',
@@ -217,18 +223,18 @@ describe('jobsActions', () => {
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: jobsTypes.JOBS_CREATING_JOB })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_CREATE_JOB_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: JobsActions.CreatingJob.type })
+      expect(actions[1].type).toEqual(JobsActions.CreateJobError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 
   describe('dismissCreateJobError()', () => {
     test('success', async () => {
-      await store.dispatch(jobsActions.dismissCreateJobError())
+      await store.dispatch(Jobs.dismissCreateJobError())
 
       expect(store.getActions()).toEqual([
-        { type: jobsTypes.JOBS_CREATE_JOB_ERROR_DISMISSED },
+        { type: JobsActions.CreateJobErrorDismissed.type },
       ])
     })
   })
@@ -239,17 +245,19 @@ describe('jobsActions', () => {
       const url = `${JOB_ENDPOINT}/${mockJob.id}`
       mockAdapter.onDelete(url).reply(200)
 
-      await store.dispatch(jobsActions.deleteJob(mockJob as any) as any)
+      await store.dispatch(Jobs.deleteJob(mockJob as any) as any)
 
       expect(clientSpies.delete.callCount).toEqual(1)
       expect(clientSpies.delete.args[0]).toEqual([url])
 
       expect(store.getActions()).toEqual([
         {
-          type: jobsTypes.JOBS_DELETING_JOB,
-          deletedJob: mockJob,
+          type: JobsActions.DeletingJob.type,
+          payload: {
+            deletedJob: mockJob,
+          },
         },
-        { type: jobsTypes.JOBS_DELETE_JOB_SUCCESS },
+        { type: JobsActions.DeleteJobSuccess.type },
       ])
     })
 
@@ -257,28 +265,32 @@ describe('jobsActions', () => {
       const mockJob = { id: 'a' }
       mockAdapter.onDelete(`${JOB_ENDPOINT}/${mockJob.id}`).reply(400)
 
-      await store.dispatch(jobsActions.deleteJob(mockJob as any) as any)
+      await store.dispatch(Jobs.deleteJob(mockJob as any) as any)
 
       const actions = store.getActions()
       expect(actions[0]).toEqual({
-        type: jobsTypes.JOBS_DELETING_JOB,
-        deletedJob: mockJob,
+        type: JobsActions.DeletingJob.type,
+        payload: {
+          deletedJob: mockJob,
+        },
       })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_DELETE_JOB_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[1].type).toEqual(JobsActions.DeleteJobError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('non-request error', async () => {
-      await store.dispatch(jobsActions.deleteJob(null as any) as any)
+      await store.dispatch(Jobs.deleteJob(null as any) as any)
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
       expect(actions[0]).toEqual({
-        type: jobsTypes.JOBS_DELETING_JOB,
-        deletedJob: null,
+        type: JobsActions.DeletingJob.type,
+        payload: {
+          deletedJob: null,
+        },
       })
-      expect(actions[1].type).toEqual(jobsTypes.JOBS_DELETE_JOB_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[1].type).toEqual(JobsActions.DeleteJobError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 })

--- a/test/actions/mapActions.test.ts
+++ b/test/actions/mapActions.test.ts
@@ -18,7 +18,7 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import thunk from 'redux-thunk'
 import configureStore, {MockStoreEnhanced} from 'redux-mock-store'
-import {mapActions, mapTypes} from '../../src/actions/mapActions'
+import {Map, MapActions} from '../../src/actions/mapActions'
 import {mapInitialState} from '../../src/reducers/mapReducer'
 import {MODE_DRAW_BBOX, MODE_NORMAL, MODE_PRODUCT_LINES, MODE_SELECT_IMAGERY} from '../../src/components/PrimaryMap'
 import {Extent, Point} from '../../src/utils/geometries'
@@ -53,13 +53,15 @@ describe('catalogActions', () => {
       const mockMap = 'a'
       const mockCollections = ['a', 'b', 'c']
 
-      await store.dispatch(mapActions.initialized(mockMap as any, mockCollections as any))
+      await store.dispatch(Map.initialized(mockMap as any, mockCollections as any))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_INITIALIZED,
-          map: mockMap,
-          collections: mockCollections,
+          type: MapActions.Initialized.type,
+          payload: {
+            map: mockMap,
+            collections: mockCollections,
+          },
         },
       ])
     })
@@ -75,12 +77,14 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.updateMode() as any)
+      await store.dispatch(Map.updateMode() as any)
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_MODE_UPDATED,
-          mode: MODE_NORMAL,
+          type: MapActions.ModeUpdated.type,
+          payload: {
+            mode: MODE_NORMAL,
+          },
         },
       ])
     })
@@ -102,12 +106,14 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.updateMode() as any)
+      await store.dispatch(Map.updateMode() as any)
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_MODE_UPDATED,
-          mode: MODE_SELECT_IMAGERY,
+          type: MapActions.ModeUpdated.type,
+          payload: {
+            mode: MODE_SELECT_IMAGERY,
+          },
         },
       ])
     })
@@ -129,12 +135,14 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.updateMode() as any)
+      await store.dispatch(Map.updateMode() as any)
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_MODE_UPDATED,
-          mode: MODE_DRAW_BBOX,
+          type: MapActions.ModeUpdated.type,
+          payload: {
+            mode: MODE_DRAW_BBOX,
+          },
         },
       ])
     })
@@ -148,12 +156,14 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.updateMode() as any)
+      await store.dispatch(Map.updateMode() as any)
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_MODE_UPDATED,
-          mode: MODE_DRAW_BBOX,
+          type: MapActions.ModeUpdated.type,
+          payload: {
+            mode: MODE_DRAW_BBOX,
+          },
         },
       ])
     })
@@ -167,12 +177,14 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.updateMode() as any)
+      await store.dispatch(Map.updateMode() as any)
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_MODE_UPDATED,
-          mode: MODE_PRODUCT_LINES,
+          type: MapActions.ModeUpdated.type,
+          payload: {
+            mode: MODE_PRODUCT_LINES,
+          },
         },
       ])
     })
@@ -182,12 +194,14 @@ describe('catalogActions', () => {
     test('success', async () => {
       const mockBbox = [1, 2, 3, 4]
 
-      await store.dispatch(mapActions.updateBbox(mockBbox as any))
+      await store.dispatch(Map.updateBbox(mockBbox as any))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_BBOX_UPDATED,
-          bbox: mockBbox,
+          type: MapActions.BboxUpdated.type,
+          payload: {
+            bbox: mockBbox,
+          },
         },
       ])
     })
@@ -195,10 +209,10 @@ describe('catalogActions', () => {
 
   describe('clearBbox()', () => {
     test('success', async () => {
-      await store.dispatch(mapActions.clearBbox())
+      await store.dispatch(Map.clearBbox())
 
       expect(store.getActions()).toEqual([
-        { type: mapTypes.MAP_BBOX_CLEARED },
+        { type: MapActions.BboxCleared.type },
       ])
     })
   })
@@ -230,15 +244,17 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateDetections() as any)
+        await store.dispatch(Map.updateDetections() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_DETECTIONS_UPDATED,
-            detections: [
-              { id: 'a' },
-              { id: 'c' },
-            ],
+            type: MapActions.DetectionsUpdated.type,
+            payload: {
+              detections: [
+                { id: 'a' },
+                { id: 'c' },
+              ],
+            },
           },
         ])
       })
@@ -269,7 +285,7 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateDetections() as any)
+        await store.dispatch(Map.updateDetections() as any)
 
         expect(store.getActions()).toEqual([])
       })
@@ -298,14 +314,16 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateDetections() as any)
+        await store.dispatch(Map.updateDetections() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_DETECTIONS_UPDATED,
-            detections: [
-              mockSelectedFeature,
-            ],
+            type: MapActions.DetectionsUpdated.type,
+            payload: {
+              detections: [
+                mockSelectedFeature,
+              ],
+            },
           },
         ])
       })
@@ -331,12 +349,14 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateDetections() as any)
+        await store.dispatch(Map.updateDetections() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_DETECTIONS_UPDATED,
-            detections: mockProductLinesRecords,
+            type: MapActions.DetectionsUpdated.type,
+            payload: {
+              detections: mockProductLinesRecords,
+            },
           },
         ])
       })
@@ -365,14 +385,16 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateDetections() as any)
+        await store.dispatch(Map.updateDetections() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_DETECTIONS_UPDATED,
-            detections: [
-              mockSelectedFeature,
-            ],
+            type: MapActions.DetectionsUpdated.type,
+            payload: {
+              detections: [
+                mockSelectedFeature,
+              ],
+            },
           },
         ])
       })
@@ -398,12 +420,14 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateDetections() as any)
+        await store.dispatch(Map.updateDetections() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_DETECTIONS_UPDATED,
-            detections: mockProductLinesRecords,
+            type: MapActions.DetectionsUpdated.type,
+            payload: {
+              detections: mockProductLinesRecords,
+            },
           },
         ])
       })
@@ -435,15 +459,17 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateFrames() as any)
+        await store.dispatch(Map.updateFrames() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_FRAMES_UPDATED,
-            frames: [
-              { id: 'a' },
-              { id: 'c' },
-            ],
+            type: MapActions.FramesUpdated.type,
+            payload: {
+              frames: [
+                { id: 'a' },
+                { id: 'c' },
+              ],
+            },
           },
         ])
       })
@@ -470,7 +496,7 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateFrames() as any)
+        await store.dispatch(Map.updateFrames() as any)
 
         expect(store.getActions()).toEqual([])
       })
@@ -500,15 +526,17 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateFrames() as any)
+        await store.dispatch(Map.updateFrames() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_FRAMES_UPDATED,
-            frames: [
-              mockSelectedFeature,
-              ...mockProductLines,
-            ],
+            type: MapActions.FramesUpdated.type,
+            payload: {
+              frames: [
+                mockSelectedFeature,
+                ...mockProductLines,
+              ],
+            },
           },
         ])
       })
@@ -534,12 +562,14 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateFrames() as any)
+        await store.dispatch(Map.updateFrames() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_FRAMES_UPDATED,
-            frames: mockProductLines,
+            type: MapActions.FramesUpdated.type,
+            payload: {
+              frames: mockProductLines,
+            },
           },
         ])
       })
@@ -569,15 +599,17 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateFrames() as any)
+        await store.dispatch(Map.updateFrames() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_FRAMES_UPDATED,
-            frames: [
-              mockSelectedFeature,
-              ...mockProductLines,
-            ],
+            type: MapActions.FramesUpdated.type,
+            payload: {
+              frames: [
+                mockSelectedFeature,
+                ...mockProductLines,
+              ],
+            },
           },
         ])
       })
@@ -603,12 +635,14 @@ describe('catalogActions', () => {
           },
         }) as any
 
-        await store.dispatch(mapActions.updateFrames() as any)
+        await store.dispatch(Map.updateFrames() as any)
 
         expect(store.getActions()).toEqual([
           {
-            type: mapTypes.MAP_FRAMES_UPDATED,
-            frames: mockProductLines,
+            type: MapActions.FramesUpdated.type,
+            payload: {
+              frames: mockProductLines,
+            },
           },
         ])
       })
@@ -627,12 +661,14 @@ describe('catalogActions', () => {
 
       const mockFeature = { id: 'a' }
 
-      await store.dispatch(mapActions.setSelectedFeature(mockFeature as any) as any)
+      await store.dispatch(Map.setSelectedFeature(mockFeature as any) as any)
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_SELECTED_FEATURE_UPDATED,
-          selectedFeature: mockFeature,
+          type: MapActions.SelectedFeatureUpdated.type,
+          payload: {
+            selectedFeature: mockFeature,
+          },
         },
       ])
     })
@@ -647,7 +683,7 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.setSelectedFeature(mockFeature as any) as any)
+      await store.dispatch(Map.setSelectedFeature(mockFeature as any) as any)
 
       expect(store.getActions()).toEqual([])
     })
@@ -657,12 +693,14 @@ describe('catalogActions', () => {
     test('success', async () => {
       const mockFeature = { id: 'a' }
 
-      await store.dispatch(mapActions.setHoveredFeature(mockFeature as any))
+      await store.dispatch(Map.setHoveredFeature(mockFeature as any))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_HOVERED_FEATURE_UPDATED,
-          hoveredFeature: mockFeature,
+          type: MapActions.HoveredFeatureUpdated.type,
+          payload: {
+            hoveredFeature: mockFeature,
+          },
         },
       ])
     })
@@ -672,12 +710,14 @@ describe('catalogActions', () => {
     test('success', async () => {
       const mockView = { some: 'data' }
 
-      await store.dispatch(mapActions.updateView(mockView as any))
+      await store.dispatch(Map.updateView(mockView as any))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_VIEW_UPDATED,
-          view: mockView,
+          type: MapActions.ViewUpdated.type,
+          payload: {
+            view: mockView,
+          },
         },
       ])
     })
@@ -688,16 +728,18 @@ describe('catalogActions', () => {
       const point = [1, 2] as Point
       const zoom = 3
 
-      await store.dispatch(mapActions.panToPoint({
+      await store.dispatch(Map.panToPoint({
         point,
         zoom,
       }))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_PAN_TO_POINT,
-          point,
-          zoom,
+          type: MapActions.PanToPoint.type,
+          payload: {
+            point,
+            zoom,
+          },
         },
       ])
     })
@@ -705,15 +747,17 @@ describe('catalogActions', () => {
     test('default zoom', async () => {
       const point = [1, 2] as Point
 
-      await store.dispatch(mapActions.panToPoint({
+      await store.dispatch(Map.panToPoint({
         point,
       }))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_PAN_TO_POINT,
-          point,
-          zoom: 10,
+          type: MapActions.PanToPoint.type,
+          payload: {
+            point,
+            zoom: 10,
+          },
         },
       ])
     })
@@ -723,12 +767,14 @@ describe('catalogActions', () => {
     test('success', async () => {
       const extent = [1, 2, 3, 4] as Extent
 
-      await store.dispatch(mapActions.panToExtent(extent))
+      await store.dispatch(Map.panToExtent(extent))
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_PAN_TO_EXTENT,
-          extent,
+          type: MapActions.PanToExtent.type,
+          payload: {
+            extent,
+          },
         },
       ])
     })
@@ -747,7 +793,7 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.serialize() as any)
+      await store.dispatch(Map.serialize() as any)
 
       // Note: coordinates should be wrapped within -180/180.
       expect(sessionStorage.setItem).toHaveBeenCalledTimes(2)
@@ -755,7 +801,7 @@ describe('catalogActions', () => {
       expect(sessionStorage.setItem).toHaveBeenCalledWith('mapView', JSON.stringify({ center: [-179, 0] }))
 
       expect(store.getActions()).toEqual([
-        { type: mapTypes.MAP_SERIALIZED },
+        { type: MapActions.Serialized.type },
       ])
     })
 
@@ -768,12 +814,12 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.serialize() as any)
+      await store.dispatch(Map.serialize() as any)
 
       expect(sessionStorage.setItem).toHaveBeenCalledWith('mapView', JSON.stringify(null))
 
       expect(store.getActions()).toEqual([
-        { type: mapTypes.MAP_SERIALIZED },
+        { type: MapActions.Serialized.type },
       ])
     })
 
@@ -790,12 +836,12 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.serialize() as any)
+      await store.dispatch(Map.serialize() as any)
 
       expect(sessionStorage.setItem).toHaveBeenCalledWith('mapView', JSON.stringify(mockView))
 
       expect(store.getActions()).toEqual([
-        { type: mapTypes.MAP_SERIALIZED },
+        { type: MapActions.Serialized.type },
       ])
     })
 
@@ -810,12 +856,12 @@ describe('catalogActions', () => {
         },
       }) as any
 
-      await store.dispatch(mapActions.serialize() as any)
+      await store.dispatch(Map.serialize() as any)
 
       expect(sessionStorage.setItem).toHaveBeenCalledWith('bbox', JSON.stringify(null))
 
       expect(store.getActions()).toEqual([
-        { type: mapTypes.MAP_SERIALIZED },
+        { type: MapActions.Serialized.type },
       ])
     })
   })
@@ -831,7 +877,7 @@ describe('catalogActions', () => {
       sessionStorage.setItem('bbox', JSON.stringify(mockStorage.bbox))
       sessionStorage.setItem('mapView', JSON.stringify(mockStorage.mapView))
 
-      await store.dispatch(mapActions.deserialize())
+      await store.dispatch(Map.deserialize())
 
       expect(sessionStorage.getItem).toHaveBeenCalledTimes(2)
       expect(sessionStorage.getItem).toHaveBeenCalledWith('bbox')
@@ -839,10 +885,28 @@ describe('catalogActions', () => {
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_DESERIALIZED,
-          deserialized: {
+          type: MapActions.Deserialized.type,
+          payload: {
             bbox: mockStorage.bbox,
             view: mockStorage.mapView,
+          },
+        },
+      ])
+    })
+
+    test('no saved data', async () => {
+      await store.dispatch(Map.deserialize())
+
+      expect(sessionStorage.getItem).toHaveBeenCalledTimes(2)
+      expect(sessionStorage.getItem).toHaveBeenCalledWith('bbox')
+      expect(sessionStorage.getItem).toHaveBeenCalledWith('mapView')
+
+      expect(store.getActions()).toEqual([
+        {
+          type: MapActions.Deserialized.type,
+          payload: {
+            bbox: null,
+            view: null,
           },
         },
       ])
@@ -852,7 +916,7 @@ describe('catalogActions', () => {
       sessionStorage.setItem('bbox', 'badJson')
       sessionStorage.setItem('mapView', 'badJson')
 
-      await store.dispatch(mapActions.deserialize())
+      await store.dispatch(Map.deserialize())
 
       expect(sessionStorage.getItem).toHaveBeenCalledTimes(2)
       expect(sessionStorage.getItem).toHaveBeenCalledWith('bbox')
@@ -860,8 +924,11 @@ describe('catalogActions', () => {
 
       expect(store.getActions()).toEqual([
         {
-          type: mapTypes.MAP_DESERIALIZED,
-          deserialized: {},
+          type: MapActions.Deserialized.type,
+          payload: {
+            bbox: mapInitialState.bbox,
+            view: mapInitialState.view,
+          },
         },
       ])
     })

--- a/test/actions/productLinesActions.test.ts
+++ b/test/actions/productLinesActions.test.ts
@@ -20,7 +20,7 @@ import thunk from 'redux-thunk'
 import configureStore, {MockStoreEnhanced} from 'redux-mock-store'
 import * as sinon from 'sinon'
 import {SinonSpy} from 'sinon'
-import {productLinesActions, productLinesTypes} from '../../src/actions/productLinesActions'
+import {ProductLines, ProductLinesActions} from '../../src/actions/productLinesActions'
 import {JOB_ENDPOINT, PRODUCTLINE_ENDPOINT} from '../../src/config'
 import {getClient} from '../../src/api/session'
 import {Extent} from '../../src/utils/geometries'
@@ -60,16 +60,18 @@ describe('productLinesActions', () => {
       }
       mockAdapter.onGet(PRODUCTLINE_ENDPOINT).reply(200, mockResponse)
 
-      await store.dispatch(productLinesActions.fetch() as any)
+      await store.dispatch(ProductLines.fetch() as any)
 
       expect(clientSpies.get.callCount).toEqual(1)
       expect(clientSpies.get.args[0]).toEqual([PRODUCTLINE_ENDPOINT])
 
       expect(store.getActions()).toEqual([
-        { type: productLinesTypes.PRODUCT_LINES_FETCHING },
+        { type: ProductLinesActions.Fetching.type },
         {
-          type: productLinesTypes.PRODUCT_LINES_FETCH_SUCCESS,
-          records: mockResponse.productlines.features,
+          type: ProductLinesActions.FetchSuccess.type,
+          payload: {
+            records: mockResponse.productlines.features,
+          },
         },
       ])
     })
@@ -77,24 +79,24 @@ describe('productLinesActions', () => {
     test('request error', async () => {
       mockAdapter.onGet(PRODUCTLINE_ENDPOINT).reply(400)
 
-      await store.dispatch(productLinesActions.fetch() as any)
+      await store.dispatch(ProductLines.fetch() as any)
 
       const actions = store.getActions()
       expect(actions.length).toEqual(2)
-      expect(actions[0]).toEqual({ type: productLinesTypes.PRODUCT_LINES_FETCHING })
-      expect(actions[1].type).toEqual(productLinesTypes.PRODUCT_LINES_FETCH_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: ProductLinesActions.Fetching.type })
+      expect(actions[1].type).toEqual(ProductLinesActions.FetchError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('invalid response data', async () => {
       mockAdapter.onGet(PRODUCTLINE_ENDPOINT).reply(200)
 
-      await store.dispatch(productLinesActions.fetch() as any)
+      await store.dispatch(ProductLines.fetch() as any)
 
       const actions = store.getActions()
-      expect(actions[0].type).toEqual(productLinesTypes.PRODUCT_LINES_FETCHING)
-      expect(actions[1].type).toEqual(productLinesTypes.PRODUCT_LINES_FETCH_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0].type).toEqual(ProductLinesActions.Fetching.type)
+      expect(actions[1].type).toEqual(ProductLinesActions.FetchError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 
@@ -114,16 +116,18 @@ describe('productLinesActions', () => {
       const url = getJobsEndpoint(productLineId, sinceDate)
       mockAdapter.onGet(url).reply(200, mockResponse)
 
-      await store.dispatch(productLinesActions.fetchJobs({ productLineId, sinceDate }) as any)
+      await store.dispatch(ProductLines.fetchJobs({ productLineId, sinceDate }) as any)
 
       expect(clientSpies.get.callCount).toEqual(1)
       expect(clientSpies.get.args[0]).toEqual([url])
 
       expect(store.getActions()).toEqual([
-        { type: productLinesTypes.PRODUCT_LINES_FETCHING_JOBS },
+        { type: ProductLinesActions.FetchingJobs.type },
         {
-          type: productLinesTypes.PRODUCT_LINES_FETCH_JOBS_SUCCESS,
-          jobs: mockResponse.jobs.features,
+          type: ProductLinesActions.FetchJobsSuccess.type,
+          payload: {
+            jobs: mockResponse.jobs.features,
+          },
         },
       ])
     })
@@ -133,12 +137,12 @@ describe('productLinesActions', () => {
       const sinceDate = '2'
       mockAdapter.onGet(getJobsEndpoint(productLineId, sinceDate)).reply(400,)
 
-      await store.dispatch(productLinesActions.fetchJobs({ productLineId, sinceDate }) as any)
+      await store.dispatch(ProductLines.fetchJobs({ productLineId, sinceDate }) as any)
 
       const actions = store.getActions()
-      expect(actions[0]).toEqual({ type: productLinesTypes.PRODUCT_LINES_FETCHING_JOBS })
-      expect(actions[1].type).toEqual(productLinesTypes.PRODUCT_LINES_FETCH_JOBS_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: ProductLinesActions.FetchingJobs.type })
+      expect(actions[1].type).toEqual(ProductLinesActions.FetchJobsError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('invalid response data', async () => {
@@ -146,12 +150,12 @@ describe('productLinesActions', () => {
       const sinceDate = '2'
       mockAdapter.onGet(getJobsEndpoint(productLineId, sinceDate)).reply(200)
 
-      await store.dispatch(productLinesActions.fetchJobs({ productLineId, sinceDate }) as any)
+      await store.dispatch(ProductLines.fetchJobs({ productLineId, sinceDate }) as any)
 
       const actions = store.getActions()
-      expect(actions[0].type).toEqual(productLinesTypes.PRODUCT_LINES_FETCHING_JOBS)
-      expect(actions[1].type).toEqual(productLinesTypes.PRODUCT_LINES_FETCH_JOBS_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0].type).toEqual(ProductLinesActions.FetchingJobs.type)
+      expect(actions[1].type).toEqual(ProductLinesActions.FetchJobsError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 
@@ -171,7 +175,7 @@ describe('productLinesActions', () => {
         maxCloudCover: 5,
         name: 'e',
       }
-      await store.dispatch(productLinesActions.create(args) as any)
+      await store.dispatch(ProductLines.create(args) as any)
 
       expect(clientSpies.post.callCount).toBe(1)
       expect(clientSpies.post.args[0]).toEqual([
@@ -192,10 +196,12 @@ describe('productLinesActions', () => {
       ])
 
       expect(store.getActions()).toEqual([
-        { type: productLinesTypes.PRODUCT_LINES_CREATING_PRODUCT_LINE },
+        { type: ProductLinesActions.CreatingProductLine.type },
         {
-          type: productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_SUCCESS,
-          createdProductLine: mockResponse.productline,
+          type: ProductLinesActions.CreateProductLineSuccess.type,
+          payload: {
+            createdProductLine: mockResponse.productline,
+          },
         },
       ])
     })
@@ -203,27 +209,27 @@ describe('productLinesActions', () => {
     test('request error', async () => {
       mockAdapter.onPost(PRODUCTLINE_ENDPOINT).reply(400)
 
-      await store.dispatch(productLinesActions.create({
+      await store.dispatch(ProductLines.create({
         bbox: [1, 2, 3, 4],
       } as any) as any)
 
       const actions = store.getActions()
-      expect(actions[0]).toEqual({ type: productLinesTypes.PRODUCT_LINES_CREATING_PRODUCT_LINE })
-      expect(actions[1].type).toEqual(productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0]).toEqual({ type: ProductLinesActions.CreatingProductLine.type })
+      expect(actions[1].type).toEqual(ProductLinesActions.CreateProductLineError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
 
     test('invalid response data', async () => {
       mockAdapter.onPost(PRODUCTLINE_ENDPOINT).reply(200)
 
-      await store.dispatch(productLinesActions.create({
+      await store.dispatch(ProductLines.create({
         bbox: [1, 2, 3, 4],
       } as any) as any)
 
       const actions = store.getActions()
-      expect(actions[0].type).toEqual(productLinesTypes.PRODUCT_LINES_CREATING_PRODUCT_LINE)
-      expect(actions[1].type).toEqual(productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_ERROR)
-      expect(actions[1].error).toBeDefined()
+      expect(actions[0].type).toEqual(ProductLinesActions.CreatingProductLine.type)
+      expect(actions[1].type).toEqual(ProductLinesActions.CreateProductLineError.type)
+      expect(actions[1].payload).toHaveProperty('error')
     })
   })
 

--- a/test/actions/routeActions.test.ts
+++ b/test/actions/routeActions.test.ts
@@ -17,7 +17,7 @@
 import thunk from 'redux-thunk'
 import configureStore, {MockStoreEnhanced} from 'redux-mock-store'
 import * as sinon from 'sinon'
-import {routeActions, routeTypes} from '../../src/actions/routeActions'
+import {Route, RouteActions} from '../../src/actions/routeActions'
 import {AppState, initialState} from '../../src/store'
 
 const mockStore = configureStore([thunk])
@@ -40,7 +40,7 @@ describe('routeActions', () => {
 
       const pushStateSpy = sinon.spy(history, 'pushState')
 
-      await store.dispatch(routeActions.navigateTo({ loc } as any))
+      await store.dispatch(Route.navigateTo({ loc } as any))
 
       const href = `${loc.pathname}${loc.search}${loc.hash}`
 
@@ -49,13 +49,15 @@ describe('routeActions', () => {
 
       expect(store.getActions()).toEqual([
         {
-          type: routeTypes.ROUTE_CHANGED,
-          pathname: loc.pathname,
-          search: loc.search,
-          hash: loc.hash,
-          selectedFeature: loc.selectedFeature,
-          href,
-          jobIds: ['1', '2', '3'],
+          type: RouteActions.Changed.type,
+          payload: {
+            pathname: loc.pathname,
+            search: loc.search,
+            hash: loc.hash,
+            selectedFeature: loc.selectedFeature,
+            href,
+            jobIds: ['1', '2', '3'],
+          },
         },
       ])
 
@@ -63,17 +65,19 @@ describe('routeActions', () => {
     })
 
     test('defaults', async () => {
-      await store.dispatch(routeActions.navigateTo({ loc: {} }))
+      await store.dispatch(Route.navigateTo({ loc: {} }))
 
       expect(store.getActions()).toEqual([
         {
-          type: routeTypes.ROUTE_CHANGED,
-          pathname: '/',
-          search: '',
-          hash: '',
-          selectedFeature: null,
-          href: '/',
-          jobIds: [],
+          type: RouteActions.Changed.type,
+          payload: {
+            pathname: '/',
+            search: '',
+            hash: '',
+            selectedFeature: null,
+            href: '/',
+            jobIds: [],
+          },
         },
       ])
     })
@@ -81,7 +85,7 @@ describe('routeActions', () => {
     test('pushHistory: false', async () => {
       const pushStateSpy = sinon.spy(history, 'pushState')
 
-      await store.dispatch(routeActions.navigateTo(({
+      await store.dispatch(Route.navigateTo(({
         loc: {},
         pushHistory: false,
       })))

--- a/test/reducers/algorithmsReducer.test.ts
+++ b/test/reducers/algorithmsReducer.test.ts
@@ -15,25 +15,11 @@
  */
 
 import {algorithmsInitialState, algorithmsReducer} from '../../src/reducers/algorithmsReducer'
-import {algorithmsTypes} from '../../src/actions/algorithmsActions'
+import {AlgorithmsActions} from '../../src/actions/algorithmsActions'
 
 describe('algorithmsReducer', () => {
   test('initial state', () => {
-    expect(algorithmsReducer(undefined, {})).toEqual(algorithmsInitialState)
-  })
-
-  test('ALGORITHMS_DESERIALIZED', () => {
-    const action = {
-      type: algorithmsTypes.ALGORITHMS_DESERIALIZED,
-      deserialized: {
-        a: 'a',
-      },
-    }
-
-    expect(algorithmsReducer(algorithmsInitialState, action)).toEqual({
-      ...algorithmsInitialState,
-      ...action.deserialized,
-    })
+    expect(algorithmsReducer(undefined, { type: null })).toEqual(algorithmsInitialState)
   })
 
   test('ALGORITHMS_FETCHING', () => {
@@ -42,7 +28,7 @@ describe('algorithmsReducer', () => {
       fetchError: 'a',
     }
 
-    const action = { type: algorithmsTypes.ALGORITHMS_FETCHING }
+    const action = { type: AlgorithmsActions.Fetching.type }
 
     expect(algorithmsReducer(state, action)).toEqual({
       ...state,
@@ -58,14 +44,16 @@ describe('algorithmsReducer', () => {
     }
 
     const action = {
-      type: algorithmsTypes.ALGORITHMS_FETCH_SUCCESS,
-      records: [1, 2, 3],
+      type: AlgorithmsActions.FetchSuccess.type,
+      payload: {
+        records: [1, 2, 3],
+      },
     }
 
     expect(algorithmsReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      records: action.records,
+      records: action.payload.records,
     })
   })
 
@@ -76,14 +64,30 @@ describe('algorithmsReducer', () => {
     }
 
     const action = {
-      type: algorithmsTypes.ALGORITHMS_FETCH_ERROR,
-      error: 'a',
+      type: AlgorithmsActions.FetchError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(algorithmsReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      fetchError: action.error,
+      fetchError: action.payload.error,
+    })
+  })
+
+  test('ALGORITHMS_DESERIALIZED', () => {
+    const action = {
+      type: AlgorithmsActions.Deserialized.type,
+      payload: {
+        records: 'a',
+      },
+    }
+
+    expect(algorithmsReducer(algorithmsInitialState, action)).toEqual({
+      ...algorithmsInitialState,
+      records: action.payload.records,
     })
   })
 })

--- a/test/reducers/apiStatusReducer.test.ts
+++ b/test/reducers/apiStatusReducer.test.ts
@@ -15,25 +15,11 @@
  */
 
 import {apiStatusInitialState, apiStatusReducer} from '../../src/reducers/apiStatusReducer'
-import {apiStatusTypes} from '../../src/actions/apiStatusActions'
+import {ApiStatusActions} from '../../src/actions/apiStatusActions'
 
 describe('apiStatusReducer', () => {
   test('initial state', () => {
-    expect(apiStatusReducer(undefined, {})).toEqual(apiStatusInitialState)
-  })
-
-  test('API_STATUS_DESERIALIZED', () => {
-    const action = {
-      type: apiStatusTypes.API_STATUS_DESERIALIZED,
-      deserialized: {
-        a: 'a',
-      },
-    }
-
-    expect(apiStatusReducer(apiStatusInitialState, action)).toEqual({
-      ...apiStatusInitialState,
-      ...action.deserialized,
-    })
+    expect(apiStatusReducer(undefined, { type: null })).toEqual(apiStatusInitialState)
   })
 
   test('API_STATUS_FETCHING', () => {
@@ -42,7 +28,7 @@ describe('apiStatusReducer', () => {
       fetchError: 'a',
     }
 
-    const action = { type: apiStatusTypes.API_STATUS_FETCHING }
+    const action = { type: ApiStatusActions.Fetching.type }
 
     expect(apiStatusReducer(state, action)).toEqual({
       ...state,
@@ -58,18 +44,20 @@ describe('apiStatusReducer', () => {
     }
 
     const action = {
-      type: apiStatusTypes.API_STATUS_FETCH_SUCCESS,
-      geoserver: {
-        wmsUrl: 'a',
+      type: ApiStatusActions.FetchSuccess.type,
+      payload: {
+        geoserver: {
+          wmsUrl: 'a',
+        },
+        enabledPlatforms: ['a', 'b', 'c'],
       },
-      enabledPlatforms: ['a', 'b', 'c'],
     }
 
     expect(apiStatusReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      geoserver: action.geoserver,
-      enabledPlatforms: action.enabledPlatforms,
+      geoserver: action.payload.geoserver,
+      enabledPlatforms: action.payload.enabledPlatforms,
     })
   })
 
@@ -80,14 +68,32 @@ describe('apiStatusReducer', () => {
     }
 
     const action = {
-      type: apiStatusTypes.API_STATUS_FETCH_ERROR,
-      error: 'a',
+      type: ApiStatusActions.FetchError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(apiStatusReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      fetchError: action.error,
+      fetchError: action.payload.error,
+    })
+  })
+
+  test('API_STATUS_DESERIALIZED', () => {
+    const action = {
+      type: ApiStatusActions.Deserialized.type,
+      payload: {
+        geoserver: 'a',
+        enabledPlatforms: 'b',
+      },
+    }
+
+    expect(apiStatusReducer(apiStatusInitialState, action)).toEqual({
+      ...apiStatusInitialState,
+      geoserver: action.payload.geoserver,
+      enabledPlatforms: action.payload.enabledPlatforms,
     })
   })
 })

--- a/test/reducers/catalogReducer.test.ts
+++ b/test/reducers/catalogReducer.test.ts
@@ -15,49 +15,38 @@
  */
 
 import {catalogInitialState, catalogReducer} from '../../src/reducers/catalogReducer'
-import {catalogTypes} from '../../src/actions/catalogActions'
-import {mapTypes} from '../../src/actions/mapActions'
-import * as moment from 'moment'
+import {CatalogActions} from '../../src/actions/catalogActions'
+import {MapActions} from '../../src/actions/mapActions'
 
 describe('catalogReducer', () => {
   test('initialState', () => {
-    expect(catalogReducer(undefined, {})).toEqual(catalogInitialState)
+    expect(catalogReducer(undefined, { type: null })).toEqual(catalogInitialState)
   })
 
-  test('CATALOG_DESERIALIZED', () => {
+  test('CATALOG_API_KEY_UPDATED', () => {
     const action = {
-      type: catalogTypes.CATALOG_DESERIALIZED,
-      deserialized: {
-        a: 'a',
+      type: CatalogActions.ApiKeyUpdated.type,
+      payload: {
+        apiKey: 'a',
       },
     }
 
     expect(catalogReducer(catalogInitialState, action)).toEqual({
       ...catalogInitialState,
-      ...action.deserialized,
-    })
-  })
-
-  test('CATALOG_API_KEY_UPDATED', () => {
-    const action = {
-      type: catalogTypes.CATALOG_API_KEY_UPDATED,
-      apiKey: 'a',
-    }
-
-    expect(catalogReducer(catalogInitialState, action)).toEqual({
-      ...catalogInitialState,
-      apiKey: action.apiKey,
+      apiKey: action.payload.apiKey,
     })
   })
 
   test('CATALOG_SEARCH_CRITERIA_UPDATED', () => {
     const action = {
-      type: catalogTypes.CATALOG_SEARCH_CRITERIA_UPDATED,
-      searchCriteria: {
-        cloudCover: 1,
-        dateFrom: moment(),
-        dateTo: moment(),
-        source: 'a',
+      type: CatalogActions.SearchCriteriaUpdated.type,
+      payload: {
+        searchCriteria: {
+          cloudCover: 'a',
+          dateFrom: 'b',
+          dateTo: 'c',
+          source: 'd',
+        },
       },
     }
 
@@ -65,7 +54,7 @@ describe('catalogReducer', () => {
       ...catalogInitialState,
       searchCriteria: {
         ...catalogInitialState.searchCriteria,
-        ...action.searchCriteria,
+        ...action.payload.searchCriteria,
       },
     })
   })
@@ -74,14 +63,14 @@ describe('catalogReducer', () => {
     const state = {
       ...catalogInitialState,
       searchCriteria: {
-        cloudCover: 1,
-        dateFrom: moment(),
-        dateTo: moment(),
-        source: 'a',
+        cloudCover: 'a',
+        dateFrom: 'b',
+        dateTo: 'c',
+        source: 'd',
       },
     } as any
 
-    const action = { type: catalogTypes.CATALOG_SEARCH_CRITERIA_RESET }
+    const action = { type: CatalogActions.SearchCriteriaReset.type }
 
     expect(catalogReducer(state, action)).toEqual({
       ...state,
@@ -95,7 +84,7 @@ describe('catalogReducer', () => {
       searchError: 'a',
     }
 
-    const action = { type: catalogTypes.CATALOG_SEARCHING }
+    const action = { type: CatalogActions.Searching.type }
 
     expect(catalogReducer(state, action)).toEqual({
       ...state,
@@ -111,14 +100,16 @@ describe('catalogReducer', () => {
     }
 
     const action = {
-      type: catalogTypes.CATALOG_SEARCH_SUCCESS,
-      searchResults: [1, 2, 3],
+      type: CatalogActions.SearchSuccess.type,
+      payload: {
+        searchResults: 'a',
+      },
     }
 
     expect(catalogReducer(state, action)).toEqual({
       ...state,
       isSearching: false,
-      searchResults: action.searchResults,
+      searchResults: action.payload.searchResults,
     })
   })
 
@@ -129,25 +120,45 @@ describe('catalogReducer', () => {
     }
 
     const action = {
-      type: catalogTypes.CATALOG_SEARCH_ERROR,
-      error: 'a',
+      type: CatalogActions.SearchError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(catalogReducer(state, action)).toEqual({
       ...state,
       isSearching: false,
-      searchError: action.error,
+      searchError: action.payload.error,
+    })
+  })
+
+  test('CATALOG_DESERIALIZED', () => {
+    const action = {
+      type: CatalogActions.Deserialized.type,
+      payload: {
+        searchCriteria: 'a',
+        searchResults: 'b',
+        apiKey: 'c',
+      },
+    }
+
+    expect(catalogReducer(catalogInitialState, action)).toEqual({
+      ...catalogInitialState,
+      searchCriteria: action.payload.searchCriteria,
+      searchResults: action.payload.searchResults,
+      apiKey: action.payload.apiKey,
     })
   })
 
   test('MAP_BBOX_CLEARED', () => {
     const state = {
       ...catalogInitialState,
-      searchResults: [1, 2, 3],
-      searchError: 'a',
+      searchResults: 'a',
+      searchError: 'b',
     } as any
 
-    const action = { type: mapTypes.MAP_BBOX_CLEARED }
+    const action = { type: MapActions.BboxCleared.type }
 
     expect(catalogReducer(state, action)).toEqual({
       ...state,

--- a/test/reducers/jobsReducer.test.ts
+++ b/test/reducers/jobsReducer.test.ts
@@ -15,11 +15,11 @@
  */
 
 import {jobsInitialState, jobsReducer, JobsState} from '../../src/reducers/jobsReducer'
-import {jobsTypes} from '../../src/actions/jobsActions'
+import {JobsActions} from '../../src/actions/jobsActions'
 
 describe('jobsReducer', () => {
   test('initialState', () => {
-    expect(jobsReducer(undefined, {})).toEqual(jobsInitialState)
+    expect(jobsReducer(undefined, { type: null })).toEqual(jobsInitialState)
   })
 
   test('JOBS_FETCHING', () => {
@@ -28,7 +28,7 @@ describe('jobsReducer', () => {
       fetchError: 'a',
     }
 
-    const action = { type: jobsTypes.JOBS_FETCHING }
+    const action = { type: JobsActions.Fetching.type }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
@@ -44,14 +44,16 @@ describe('jobsReducer', () => {
     }
 
     const action = {
-      type: jobsTypes.JOBS_FETCH_SUCCESS,
-      records: ['a', 'b', 'c'],
+      type: JobsActions.FetchSuccess.type,
+      payload: {
+        records: 'a',
+      },
     }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      records: action.records,
+      records: action.payload.records,
       initialFetchComplete: true,
     })
   })
@@ -63,14 +65,16 @@ describe('jobsReducer', () => {
     }
 
     const action = {
-      type: jobsTypes.JOBS_FETCH_ERROR,
-      error: 'a',
+      type: JobsActions.FetchError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      fetchError: action.error,
+      fetchError: action.payload.error,
     })
   })
 
@@ -80,7 +84,7 @@ describe('jobsReducer', () => {
       fetchOneError: 'a',
     }
 
-    const action = { type: jobsTypes.JOBS_FETCHING_ONE }
+    const action = { type: JobsActions.FetchingOne.type }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
@@ -96,15 +100,17 @@ describe('jobsReducer', () => {
     }
 
     const action = {
-      type: jobsTypes.JOBS_FETCH_ONE_SUCCESS,
-      record: 'a',
+      type: JobsActions.FetchOneSuccess.type,
+      payload: {
+        record: 'a',
+      },
     }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
       isFetchingOne: false,
-      records: [...state.records, action.record],
-      lastOneFetched: action.record,
+      records: [...state.records, action.payload.record],
+      lastOneFetched: action.payload.record,
     })
   })
 
@@ -115,14 +121,16 @@ describe('jobsReducer', () => {
     }
 
     const action = {
-      type: jobsTypes.JOBS_FETCH_ONE_ERROR,
-      error: 'a',
+      type: JobsActions.FetchOneError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
       isFetchingOne: false,
-      fetchOneError: action.error,
+      fetchOneError: action.payload.error,
     })
   })
 
@@ -130,10 +138,10 @@ describe('jobsReducer', () => {
     const state = {
       ...jobsInitialState,
       createdJob: 'a',
-      createJobError: 'a',
+      createJobError: 'b',
     }
 
-    const action = { type: jobsTypes.JOBS_CREATING_JOB }
+    const action = { type: JobsActions.CreatingJob.type }
 
     expect(jobsReducer(state as any, action)).toEqual({
       ...state,
@@ -151,15 +159,17 @@ describe('jobsReducer', () => {
     }
 
     const action = {
-      type: jobsTypes.JOBS_CREATE_JOB_SUCCESS,
-      createdJob: 'a',
+      type: JobsActions.CreateJobSuccess.type,
+      payload: {
+        createdJob: 'a',
+      },
     }
 
     expect(jobsReducer(state as any, action)).toEqual({
       ...state,
       isCreatingJob: false,
-      createdJob: action.createdJob,
-      records: [...state.records, action.createdJob],
+      createdJob: action.payload.createdJob,
+      records: [...state.records, action.payload.createdJob],
     })
   })
 
@@ -170,14 +180,16 @@ describe('jobsReducer', () => {
     }
 
     const action = {
-      type: jobsTypes.JOBS_CREATE_JOB_ERROR,
-      error: 'a',
+      type: JobsActions.CreateJobError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
       isCreatingJob: false,
-      createJobError: action.error,
+      createJobError: action.payload.error,
     })
   })
 
@@ -187,7 +199,7 @@ describe('jobsReducer', () => {
       createJobError: 'a',
     }
 
-    const action = { type: jobsTypes.JOBS_CREATE_JOB_ERROR_DISMISSED }
+    const action = { type: JobsActions.CreateJobErrorDismissed.type }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
@@ -198,22 +210,21 @@ describe('jobsReducer', () => {
   test('JOBS_DELETING_JOB', () => {
     const state = {
       ...jobsInitialState,
-      records: [
-        { id: 'a' },
-        { id: 'b' },
-      ],
-      deletedJobError: 'a',
+      records: [{ id: 'a' }, { id: 'b' }],
+      deletedJobError: 'c',
     }
 
     const action = {
-      type: jobsTypes.JOBS_DELETING_JOB,
-      deletedJob: { id: 'a' },
+      type: JobsActions.DeletingJob.type,
+      payload: {
+        deletedJob: { id: 'a' },
+      },
     }
 
     expect(jobsReducer(state as any, action)).toEqual({
       ...state,
       isDeletingJob: true,
-      deletedJob: action.deletedJob,
+      deletedJob: action.payload.deletedJob,
       deleteJobError: null,
       records: [{ id: 'b' }],
     })
@@ -225,7 +236,7 @@ describe('jobsReducer', () => {
       isDeletingJob: true,
     }
 
-    const action = { type: jobsTypes.JOBS_DELETE_JOB_SUCCESS }
+    const action = { type: JobsActions.DeleteJobSuccess.type }
 
     expect(jobsReducer(state, action)).toEqual({
       ...state,
@@ -237,19 +248,21 @@ describe('jobsReducer', () => {
     const state = {
       ...jobsInitialState,
       isDeletingJob: true,
-      deletedJob: { id: 'a' },
-      records: [{ id: 'b' }],
+      deletedJob: 'a',
+      records: ['b'],
     }
 
     const action = {
-      type: jobsTypes.JOBS_DELETE_JOB_ERROR,
-      error: 'a',
+      type: JobsActions.DeleteJobError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(jobsReducer(state as any, action)).toEqual({
       ...state,
       isDeletingJob: false,
-      deleteJobError: action.error,
+      deleteJobError: action.payload.error,
       records: [...state.records, state.deletedJob],
     })
   })

--- a/test/reducers/mapReducer.test.ts
+++ b/test/reducers/mapReducer.test.ts
@@ -15,157 +15,153 @@
  */
 
 import {mapInitialState, mapReducer} from '../../src/reducers/mapReducer'
-import {mapTypes} from '../../src/actions/mapActions'
+import {MapActions} from '../../src/actions/mapActions'
 import {TYPE_JOB} from '../../src/constants'
 
 describe('mapReducer', () => {
   test('initialState', () => {
-    expect(mapReducer(undefined, {})).toEqual(mapInitialState)
+    expect(mapReducer(undefined, { type: null })).toEqual(mapInitialState)
   })
 
   test('MAP_INITIALIZED', () => {
     const action = {
-      type: mapTypes.MAP_INITIALIZED,
-      map: 'a',
-      collections: [1, 2, 3],
-    } as any
-
-    expect(mapReducer(mapInitialState, action)).toEqual({
-      ...mapInitialState,
-      map: action.map,
-      collections: action.collections,
-    })
-  })
-
-  test('MAP_DESERIALIZED', () => {
-    const action = {
-      type: mapTypes.MAP_DESERIALIZED,
-      deserialized: {
-        a: 'a',
+      type: MapActions.Initialized.type,
+      payload: {
+        map: 'a',
+        collections: 'b',
       },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      ...action.deserialized,
+      map: action.payload.map,
+      collections: action.payload.collections,
     })
   })
 
   test('MAP_MODE_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_MODE_UPDATED,
-      mode: 'a',
+      type: MapActions.ModeUpdated.type,
+      payload: {
+        mode: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      mode: action.mode,
+      mode: action.payload.mode,
     })
   })
 
   test('MAP_BBOX_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_BBOX_UPDATED,
-      bbox: [1, 2, 3, 4],
+      type: MapActions.BboxUpdated.type,
+      payload: {
+        bbox: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      bbox: action.bbox,
+      bbox: action.payload.bbox,
     })
   })
 
   test('MAP_BBOX_CLEARED', () => {
     const state = {
       ...mapInitialState,
-      bbox: [1, 2, 3, 4],
-      searchResults: 'a',
-      searchError: 'a',
+      bbox: 'a',
       selectedFeature: {
         properties: {
-          type: 'NON_IGNORED_TYPE',
+          type: 'd',
         },
       },
     } as any
 
-    const action = { type: mapTypes.MAP_BBOX_CLEARED }
+    const action = { type: MapActions.BboxCleared.type }
 
-    // Should auto deselect job.
+    // Should auto deselect feature.
     expect(mapReducer(state, action)).toEqual({
       ...state,
       bbox: null,
-      searchResults: null,
-      searchError: null,
       selectedFeature: null,
     })
 
-    // Should not auto-deselect job.
+    // Should not auto-deselect feature.
     state.selectedFeature.properties.type = TYPE_JOB
     expect(mapReducer(state, action)).toEqual({
       ...state,
       bbox: null,
-      searchResults: null,
-      searchError: null,
     })
   })
 
   test('MAP_DETECTIONS_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_DETECTIONS_UPDATED,
-      detections: [1, 2, 3],
+      type: MapActions.DetectionsUpdated.type,
+      payload: {
+        detections: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      detections: action.detections,
+      detections: action.payload.detections,
     })
   })
 
   test('MAP_FRAMES_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_FRAMES_UPDATED,
-      frames: [1, 2, 3],
+      type: MapActions.FramesUpdated.type,
+      payload: {
+        frames: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      frames: action.frames,
+      frames: action.payload.frames,
     })
   })
 
   test('MAP_SELECTED_FEATURE_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_SELECTED_FEATURE_UPDATED,
-      selectedFeature: 'a',
+      type: MapActions.SelectedFeatureUpdated.type,
+      payload: {
+        selectedFeature: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      selectedFeature: action.selectedFeature,
+      selectedFeature: action.payload.selectedFeature,
     })
   })
 
   test('MAP_HOVERED_FEATURE_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_HOVERED_FEATURE_UPDATED,
-      hoveredFeature: 'a',
+      type: MapActions.HoveredFeatureUpdated.type,
+      payload: {
+        hoveredFeature: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      hoveredFeature: action.hoveredFeature,
+      hoveredFeature: action.payload.hoveredFeature,
     })
   })
 
   test('MAP_VIEW_UPDATED', () => {
     const action = {
-      type: mapTypes.MAP_VIEW_UPDATED,
-      view: 'a',
+      type: MapActions.ViewUpdated.type,
+      payload: {
+        view: 'a',
+      },
     }
 
     expect(mapReducer(mapInitialState, action)).toEqual({
       ...mapInitialState,
-      view: action.view,
+      view: action.payload.view,
     })
   })
 
@@ -173,25 +169,27 @@ describe('mapReducer', () => {
     const state = {
       ...mapInitialState,
       view: {
-        basemapIndex: 0,
+        basemapIndex: 'a',
         point: null,
         zoom: null,
-        extent: [1, 2, 3, 4],
+        extent: 'b',
       },
     } as any
 
     const action = {
-      type: mapTypes.MAP_PAN_TO_POINT,
-      point: [1, 2],
-      zoom: 1,
+      type: MapActions.PanToPoint.type,
+      payload: {
+        point: 'c',
+        zoom: 'd',
+      },
     }
 
     expect(mapReducer(state, action)).toEqual({
       ...state,
       view: {
         ...state.view,
-        center: action.point,
-        zoom: action.zoom,
+        center: action.payload.point,
+        zoom: action.payload.zoom,
         extent: null,
       },
     })
@@ -201,26 +199,44 @@ describe('mapReducer', () => {
     const state = {
       ...mapInitialState,
       view: {
-        basemapIndex: 0,
-        point: [1, 2],
-        zoom: 1,
+        basemapIndex: 'a',
+        point: 'b',
+        zoom: 'c',
         extent: null,
       },
     } as any
 
     const action = {
-      type: mapTypes.MAP_PAN_TO_EXTENT,
-      extent: [1, 2, 3, 4],
+      type: MapActions.PanToExtent.type,
+      payload: {
+        extent: 'd',
+      },
     }
 
     expect(mapReducer(state, action)).toEqual({
       ...state,
       view: {
         ...state.view,
-        extent: action.extent,
+        extent: action.payload.extent,
         center: null,
         zoom: null,
       },
+    })
+  })
+
+  test('MAP_DESERIALIZED', () => {
+    const action = {
+      type: MapActions.Deserialized.type,
+      payload: {
+        bbox: 'a',
+        view: 'b',
+      },
+    }
+
+    expect(mapReducer(mapInitialState, action)).toEqual({
+      ...mapInitialState,
+      bbox: action.payload.bbox,
+      view: action.payload.view,
     })
   })
 })

--- a/test/reducers/productLinesReducer.test.ts
+++ b/test/reducers/productLinesReducer.test.ts
@@ -15,11 +15,11 @@
  */
 
 import {productLinesInitialState, productLinesReducer} from '../../src/reducers/productLinesReducer'
-import {productLinesTypes} from '../../src/actions/productLinesActions'
+import {ProductLinesActions} from '../../src/actions/productLinesActions'
 
 describe('productLinesReducer', () => {
   test('initialState', () => {
-    expect(productLinesReducer(undefined, {})).toEqual(productLinesInitialState)
+    expect(productLinesReducer(undefined, { type: null })).toEqual(productLinesInitialState)
   })
 
   test('PRODUCT_LINES_FETCHING', () => {
@@ -28,7 +28,7 @@ describe('productLinesReducer', () => {
       fetchError: 'a',
     }
 
-    const action = { type: productLinesTypes.PRODUCT_LINES_FETCHING }
+    const action = { type: ProductLinesActions.Fetching.type }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
@@ -44,14 +44,16 @@ describe('productLinesReducer', () => {
     }
 
     const action = {
-      type: productLinesTypes.PRODUCT_LINES_FETCH_SUCCESS,
-      records: [1, 2, 3],
+      type: ProductLinesActions.FetchSuccess.type,
+      payload: {
+        records: 'a',
+      },
     }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      records: action.records,
+      records: action.payload.records,
     })
   })
 
@@ -62,14 +64,16 @@ describe('productLinesReducer', () => {
     }
 
     const action = {
-      type: productLinesTypes.PRODUCT_LINES_FETCH_ERROR,
-      error: 'a',
+      type: ProductLinesActions.FetchError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
       isFetching: false,
-      fetchError: action.error,
+      fetchError: action.payload.error,
     })
   })
 
@@ -79,7 +83,7 @@ describe('productLinesReducer', () => {
       fetchJobsError: 'a',
     }
 
-    const action = { type: productLinesTypes.PRODUCT_LINES_FETCHING_JOBS }
+    const action = { type: ProductLinesActions.FetchingJobs.type }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
@@ -95,14 +99,16 @@ describe('productLinesReducer', () => {
     }
 
     const action = {
-      type: productLinesTypes.PRODUCT_LINES_FETCH_JOBS_SUCCESS,
-      jobs: [1, 2, 3],
+      type: ProductLinesActions.FetchJobsSuccess.type,
+      payload: {
+        jobs: 'a',
+      },
     }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
       isFetchingJobs: false,
-      jobs: action.jobs,
+      jobs: action.payload.jobs,
     })
   })
 
@@ -113,14 +119,16 @@ describe('productLinesReducer', () => {
     }
 
     const action = {
-      type: productLinesTypes.PRODUCT_LINES_FETCH_JOBS_ERROR,
-      error: 'a',
+      type: ProductLinesActions.FetchJobsError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
       isFetchingJobs: false,
-      fetchJobsError: action.error,
+      fetchJobsError: action.payload.error,
     })
   })
 
@@ -128,10 +136,10 @@ describe('productLinesReducer', () => {
     const state = {
       ...productLinesInitialState,
       createdProductLine: 'a',
-      createProductLineError: 'a',
+      createProductLineError: 'b',
     } as any
 
-    const action = { type: productLinesTypes.PRODUCT_LINES_CREATING_PRODUCT_LINE }
+    const action = { type: ProductLinesActions.CreatingProductLine.type }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...productLinesInitialState,
@@ -149,15 +157,17 @@ describe('productLinesReducer', () => {
     } as any
 
     const action = {
-      type: productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_SUCCESS,
-      createdProductLine: 'a',
+      type: ProductLinesActions.CreateProductLineSuccess.type,
+      payload: {
+        createdProductLine: 'b',
+      },
     }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
       isCreatingProductLine: false,
-      createdProductLine: action.createdProductLine,
-      records: [...state.records, action.createdProductLine],
+      createdProductLine: action.payload.createdProductLine,
+      records: [...state.records, action.payload.createdProductLine],
     })
   })
 
@@ -168,14 +178,16 @@ describe('productLinesReducer', () => {
     }
 
     const action = {
-      type: productLinesTypes.PRODUCT_LINES_CREATE_PRODUCT_LINE_ERROR,
-      error: 'a',
+      type: ProductLinesActions.CreateProductLineError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(productLinesReducer(state, action)).toEqual({
       ...state,
       isCreatingProductLine: false,
-      createProductLineError: action.error,
+      createProductLineError: action.payload.error,
     })
   })
 })

--- a/test/reducers/routeReducer.test.ts
+++ b/test/reducers/routeReducer.test.ts
@@ -15,32 +15,34 @@
  */
 
 import {routeInitialState, routeReducer} from '../../src/reducers/routeReducer'
-import {routeTypes} from '../../src/actions/routeActions'
+import {RouteActions} from '../../src/actions/routeActions'
 
 describe('routeReducer', () => {
   test('initialState', () => {
-    expect(routeReducer(undefined, {})).toEqual(routeInitialState)
+    expect(routeReducer(undefined, { type: null })).toEqual(routeInitialState)
   })
 
   test('ROUTE_CHANGED', () => {
     const action = {
-      type: routeTypes.ROUTE_CHANGED,
-      hash: 'a',
-      href: 'a',
-      jobIds: ['a', 'b', 'c'],
-      pathname: 'a',
-      search: 'a',
-      selectedFeature: 'a',
+      type: RouteActions.Changed.type,
+      payload: {
+        hash: 'a',
+        href: 'b',
+        jobIds: 'c',
+        pathname: 'd',
+        search: 'e',
+        selectedFeature: 'f',
+      },
     }
 
     expect(routeReducer(routeInitialState, action)).toEqual({
       ...routeInitialState,
-      hash: action.hash,
-      href: action.href,
-      jobIds: action.jobIds,
-      pathname: action.pathname,
-      search: action.search,
-      selectedFeature: action.selectedFeature,
+      hash: action.payload.hash,
+      href: action.payload.href,
+      jobIds: action.payload.jobIds,
+      pathname: action.payload.pathname,
+      search: action.payload.search,
+      selectedFeature: action.payload.selectedFeature,
     })
   })
 })

--- a/test/reducers/tourReducer.test.ts
+++ b/test/reducers/tourReducer.test.ts
@@ -15,22 +15,24 @@
  */
 
 import {tourInitialState, tourReducer} from '../../src/reducers/tourReducer'
-import {tourTypes} from '../../src/actions/tourActions'
+import {TourActions} from '../../src/actions/tourActions'
 
 describe('tourReducer', () => {
   test('initialState', () => {
-    expect(tourReducer(undefined, {})).toEqual(tourInitialState)
+    expect(tourReducer(undefined, { type: null })).toEqual(tourInitialState)
   })
 
   test('TOUR_STEPS_UPDATED', () => {
     const action = {
-      type: tourTypes.TOUR_STEPS_UPDATED,
-      steps: [1, 2, 3],
+      type: TourActions.StepsUpdated.type,
+      payload: {
+        steps: 'a',
+      },
     }
 
     expect(tourReducer(tourInitialState, action)).toEqual({
       ...tourInitialState,
-      steps: action.steps,
+      steps: action.payload.steps,
     })
   })
 
@@ -40,9 +42,9 @@ describe('tourReducer', () => {
       changing: true,
       step: 5,
       error: 'a',
-    }
+    } as any
 
-    const action = { type: tourTypes.TOUR_STARTED }
+    const action = { type: TourActions.Started.type }
 
     expect(tourReducer(state, action)).toEqual({
       ...state,
@@ -59,9 +61,9 @@ describe('tourReducer', () => {
       inProgress: true,
       changing: true,
       error: 'a',
-    }
+    } as any
 
-    const action = { type: tourTypes.TOUR_ENDED }
+    const action = { type: TourActions.Ended.type }
 
     expect(tourReducer(state, action)).toEqual({
       ...state,
@@ -72,7 +74,7 @@ describe('tourReducer', () => {
   })
 
   test('TOUR_STEP_CHANGING', () => {
-    const action = { type: tourTypes.TOUR_STEP_CHANGING }
+    const action = { type: TourActions.StepChanging.type }
 
     expect(tourReducer(tourInitialState, action)).toEqual({
       ...tourInitialState,
@@ -87,14 +89,16 @@ describe('tourReducer', () => {
     }
 
     const action = {
-      type: tourTypes.TOUR_STEP_CHANGE_SUCCESS,
-      step: 2,
+      type: TourActions.StepChangeSuccess.type,
+      payload: {
+        step: 'a',
+      },
     }
 
     expect(tourReducer(state, action)).toEqual({
       ...state,
       changing: false,
-      step: action.step,
+      step: action.payload.step,
     })
   })
 
@@ -105,14 +109,16 @@ describe('tourReducer', () => {
     }
 
     const action = {
-      type: tourTypes.TOUR_STEP_CHANGE_ERROR,
-      error: 'a',
+      type: TourActions.StepChangeError.type,
+      payload: {
+        error: 'a',
+      },
     }
 
     expect(tourReducer(state, action)).toEqual({
       ...state,
       changing: false,
-      error: action.error,
+      error: action.payload.error,
     })
   })
 })

--- a/test/reducers/userReducer.test.ts
+++ b/test/reducers/userReducer.test.ts
@@ -15,25 +15,11 @@
  */
 
 import {userInitialState, userReducer} from '../../src/reducers/userReducer'
-import {userTypes} from '../../src/actions/userActions'
+import {UserActions} from '../../src/actions/userActions'
 
 describe('userReducer', () => {
   test('initialState', () => {
-    expect(userReducer(undefined, {})).toEqual(userInitialState)
-  })
-
-  test('USER_DESERIALIZED', () => {
-    const action = {
-      type: userTypes.USER_DESERIALIZED,
-      deserialized: {
-        a: 'a',
-      },
-    }
-
-    expect(userReducer(userInitialState, action)).toEqual({
-      ...userInitialState,
-      ...action.deserialized,
-    })
+    expect(userReducer(undefined, { type: null })).toEqual(userInitialState)
   })
 
   test('USER_LOGGED_OUT', () => {
@@ -42,7 +28,7 @@ describe('userReducer', () => {
       isLoggedIn: true,
     }
 
-    const action = { type: userTypes.USER_LOGGED_OUT }
+    const action = { type: UserActions.LoggedOut.type }
 
     expect(userReducer(state, action)).toEqual({
       ...state,
@@ -58,7 +44,7 @@ describe('userReducer', () => {
       isSessionExpired: true,
     }
 
-    const action = { type: userTypes.USER_SESSION_CLEARED }
+    const action = { type: UserActions.SessionCleared.type }
 
     expect(userReducer(state, action)).toEqual({
       ...state,
@@ -74,7 +60,7 @@ describe('userReducer', () => {
       isSessionLoggedOut: true,
     }
 
-    const action = { type: userTypes.USER_SESSION_LOGGED_OUT }
+    const action = { type: UserActions.SessionLoggedOut.type }
 
     expect(userReducer(state, action)).toEqual({
       ...state,
@@ -84,11 +70,25 @@ describe('userReducer', () => {
   })
 
   test('USER_SESSION_EXPIRED', () => {
-    const action = { type: userTypes.USER_SESSION_EXPIRED }
+    const action = { type: UserActions.SessionExpired.type }
 
     expect(userReducer(userInitialState, action)).toEqual({
       ...userInitialState,
       isSessionExpired: true,
+    })
+  })
+
+  test('USER_DESERIALIZED', () => {
+    const action = {
+      type: UserActions.Deserialized.type,
+      payload: {
+        isSessionExpired: 'a',
+      },
+    }
+
+    expect(userReducer(userInitialState, action)).toEqual({
+      ...userInitialState,
+      isSessionExpired: action.payload.isSessionExpired,
     })
   })
 })


### PR DESCRIPTION
This is a code quality enhancement which will keep actions and their payloads from being a blind spot for TypeScript in the reducers. It's based on an architecture that @fsufitch had showed me, which involves creating a class for each action defining its type and its payload. Then, in the reducer, once the type of the action is confirmed, the action is cast to its proper class in order to type check its payload.

This solution involves writing a bit of extra boilerplate code for new actions, but it makes the code way tighter. As far as I can tell, it's about the simplest possible solution.

One odd compromise I had to make was to destructure all of the new action instances, since Redux expects plain objects to be dispatched. So, for example, instead of writing this...

`dispatch(new AlgorithmsActions.Fetching())`

I had to write this...

`dispatch({...new AlgorithmsActions.Fetching()})`

It's no big deal. However, it doesn't really feel like the "correct" solution. Maybe @fsufitch will have an idea on how to get around this. I just left it for now since it's not hurting anything. It might actually be the simplest solution.