### PR TITLE
Fix bug where job details don't show during tour.

### DIFF
--- a/src/components/UserTour.tsx
+++ b/src/components/UserTour.tsx
@@ -494,7 +494,7 @@ export class UserTour extends React.Component<Props> {
           const elem = query('.JobStatusList-root .JobStatus-isActive')
 
           if (!elem.classList.contains('JobStatus-isExpanded')) {
-            const details = elem.querySelector('.JobStatus-details') as HTMLElement
+            const details = elem.querySelector('.JobStatus-caret') as HTMLElement
             details.click()
           }
         },
@@ -553,7 +553,7 @@ export class UserTour extends React.Component<Props> {
           const elem = query('.JobStatusList-root .JobStatus-isActive')
 
           if (!elem.classList.contains('JobStatus-isExpanded')) {
-            (elem.querySelector('.JobStatus-details') as HTMLElement).click()
+            (elem.querySelector('.JobStatus-caret') as HTMLElement).click()
           }
         },
       },
@@ -639,7 +639,7 @@ export class UserTour extends React.Component<Props> {
         if (!elem || Array.from(elem.classList).find(n => n === 'JobStatus-isExpanded')) {
           resolve()
         } else {
-          (elem.querySelector('.JobStatus-details') as any).click()
+          (elem.querySelector('.JobStatus-caret') as any).click()
           setTimeout(resolve, 250)
         }
       }).catch(msg => reject(msg))


### PR DESCRIPTION
After the job gets created during the tour, a bubble was shown explaining the job details but the details weren't being shown. This was a bug caused back when I made the chevron the primary target for expanding job details.

![selection_098](https://user-images.githubusercontent.com/3220897/50501425-dfac3100-0a0c-11e9-83bf-3f1170f6b336.png)
