### PR TITLE
Make Redux states readonly to help enforce immutability.

### DIFF
--- a/src/reducers/algorithmsReducer.ts
+++ b/src/reducers/algorithmsReducer.ts
@@ -18,9 +18,9 @@ import {Action} from 'redux'
 import {AlgorithmsActions as Actions} from '../actions/algorithmsActions'
 
 export interface AlgorithmsState {
-  records: beachfront.Algorithm[]
-  isFetching: boolean
-  fetchError: any
+  readonly records: beachfront.Algorithm[]
+  readonly isFetching: boolean
+  readonly fetchError: any
 }
 
 export const algorithmsInitialState: AlgorithmsState = {

--- a/src/reducers/apiStatusReducer.ts
+++ b/src/reducers/apiStatusReducer.ts
@@ -18,12 +18,12 @@ import {ApiStatusActions as Actions} from '../actions/apiStatusActions'
 import {Action} from 'redux'
 
 export interface ApiStatusState {
-  geoserver: {
-    wmsUrl: string | null
+  readonly geoserver: {
+    readonly wmsUrl: string | null
   }
-  enabledPlatforms: string[]
-  isFetching: boolean
-  fetchError: any
+  readonly enabledPlatforms: string[]
+  readonly isFetching: boolean
+  readonly fetchError: any
 }
 
 export const apiStatusInitialState: ApiStatusState = {

--- a/src/reducers/catalogReducer.ts
+++ b/src/reducers/catalogReducer.ts
@@ -23,16 +23,16 @@ import {SOURCE_DEFAULT} from '../constants'
 const DATE_FORMAT = 'YYYY-MM-DD'
 
 export interface CatalogState {
-  apiKey: string
-  isSearching: boolean
-  searchCriteria: {
-    cloudCover: number
-    dateFrom: string
-    dateTo: string
-    source: string
+  readonly apiKey: string
+  readonly isSearching: boolean
+  readonly searchCriteria: {
+    readonly cloudCover: number
+    readonly dateFrom: string
+    readonly dateTo: string
+    readonly source: string
   },
-  searchError: any
-  searchResults: beachfront.ImageryCatalogPage | null
+  readonly searchError: any
+  readonly searchResults: beachfront.ImageryCatalogPage | null
 }
 
 export const catalogInitialState: CatalogState = {

--- a/src/reducers/jobsReducer.ts
+++ b/src/reducers/jobsReducer.ts
@@ -18,19 +18,19 @@ import {Action} from 'redux'
 import {JobsActions as Actions} from '../actions/jobsActions'
 
 export type JobsState = {
-  records: beachfront.Job[]
-  isFetching: boolean
-  fetchError: any
-  initialFetchComplete: boolean
-  isFetchingOne: boolean
-  fetchOneError: any
-  lastOneFetched: beachfront.Job | null
-  isDeletingJob: boolean
-  deletedJob: beachfront.Job | null
-  deleteJobError: any
-  isCreatingJob: boolean
-  createdJob: beachfront.Job | null
-  createJobError: any
+  readonly records: beachfront.Job[]
+  readonly isFetching: boolean
+  readonly fetchError: any
+  readonly initialFetchComplete: boolean
+  readonly isFetchingOne: boolean
+  readonly fetchOneError: any
+  readonly lastOneFetched: beachfront.Job | null
+  readonly isDeletingJob: boolean
+  readonly deletedJob: beachfront.Job | null
+  readonly deleteJobError: any
+  readonly isCreatingJob: boolean
+  readonly createdJob: beachfront.Job | null
+  readonly createJobError: any
 }
 
 export const jobsInitialState: JobsState = {

--- a/src/reducers/mapReducer.ts
+++ b/src/reducers/mapReducer.ts
@@ -22,10 +22,10 @@ import {Extent} from '../utils/geometries'
 import {Action} from 'redux'
 
 export interface MapCollections {
-  hovered: ol.Collection<ol.Feature>
-  imagery: ol.Collection<ol.Feature>
-  selected: ol.Collection<ol.Feature>
-  handleSelectFeature: (featureOrId: any) => void
+  readonly hovered: ol.Collection<ol.Feature>
+  readonly imagery: ol.Collection<ol.Feature>
+  readonly selected: ol.Collection<ol.Feature>
+  readonly handleSelectFeature: (featureOrId: any) => void
 }
 
 export interface MapState {

--- a/src/reducers/productLinesReducer.ts
+++ b/src/reducers/productLinesReducer.ts
@@ -18,15 +18,15 @@ import {Action} from 'redux'
 import {ProductLinesActions as Actions} from '../actions/productLinesActions'
 
 export interface ProductLinesState {
-  records: beachfront.ProductLine[]
-  isFetching: boolean
-  fetchError: any
-  jobs: beachfront.Job[]
-  isFetchingJobs: boolean
-  fetchJobsError: any
-  isCreatingProductLine: boolean
-  createdProductLine: beachfront.ProductLine | null
-  createProductLineError: any
+  readonly records: beachfront.ProductLine[]
+  readonly isFetching: boolean
+  readonly fetchError: any
+  readonly jobs: beachfront.Job[]
+  readonly isFetchingJobs: boolean
+  readonly fetchJobsError: any
+  readonly isCreatingProductLine: boolean
+  readonly createdProductLine: beachfront.ProductLine | null
+  readonly createProductLineError: any
 }
 
 export const productLinesInitialState: ProductLinesState = {

--- a/src/reducers/routeReducer.ts
+++ b/src/reducers/routeReducer.ts
@@ -19,12 +19,12 @@ import {RouteActions as Actions} from '../actions/routeActions'
 import {generateRoute} from '../utils/routeUtils'
 
 export interface RouteState {
-  hash: string
-  href: string
-  jobIds: string[]
-  pathname: string
-  search: string
-  selectedFeature: GeoJSON.Feature<any> | null
+  readonly hash: string
+  readonly href: string
+  readonly jobIds: string[]
+  readonly pathname: string
+  readonly search: string
+  readonly selectedFeature: GeoJSON.Feature<any> | null
 }
 
 export const routeInitialState: RouteState = generateRoute(location)

--- a/src/reducers/tourReducer.ts
+++ b/src/reducers/tourReducer.ts
@@ -18,11 +18,11 @@ import {Action} from 'redux'
 import {TourActions as Actions, TourStep} from '../actions/tourActions'
 
 export interface TourState {
-  inProgress: boolean
-  changing: boolean
-  step: number
-  error: Error | null
-  steps: TourStep[]
+  readonly inProgress: boolean
+  readonly changing: boolean
+  readonly step: number
+  readonly error: Error | null
+  readonly steps: TourStep[]
 }
 
 export const tourInitialState: TourState = {

--- a/src/reducers/userReducer.ts
+++ b/src/reducers/userReducer.ts
@@ -19,10 +19,10 @@ import {UserActions as Actions} from '../actions/userActions'
 import * as session from '../api/session'
 
 export interface UserState {
-  isLoggedIn: boolean
-  isSessionExpired: boolean
-  isSessionLoggedOut: boolean
-  catalogApiKey: string
+  readonly isLoggedIn: boolean
+  readonly isSessionExpired: boolean
+  readonly isSessionLoggedOut: boolean
+  readonly catalogApiKey: string
 }
 
 export const userInitialState: UserState = {


### PR DESCRIPTION
This is just a safeguard to ensure that application states are modified in the proper Redux way in the future.