### PR TITLE
Use explicit error types in application states.

### DIFF
--- a/src/components/AlgorithmList.tsx
+++ b/src/components/AlgorithmList.tsx
@@ -46,13 +46,15 @@ export const AlgorithmList = (props: Props) => (
             warningMessage={props.warningMessage}
             onSelect={props.onSelect}
             onSubmit={props.onSubmit}
-            errorElement={props.jobs.createJobError && (
+            errorElement={props.jobs.createJobError ? (
               <div className={styles.errorMessage}>
                 <h4><i className="fa fa-warning"/> Algorithm failed</h4>
-                <p>{props.jobs.createJobError.response.data}</p>
+                {props.jobs.createJobError.response && (
+                  <p>{props.jobs.createJobError.response.data}</p>
+                )}
                 <pre>{props.jobs.createJobError.stack}</pre>
               </div>
-            )}
+            ) : <div></div>}
           />
         </li>
       ))}

--- a/src/components/CatalogSearchCriteria.tsx
+++ b/src/components/CatalogSearchCriteria.tsx
@@ -187,16 +187,15 @@ export class CatalogSearchCriteria extends React.Component<Props> {
   }
 
   private renderErrorElement() {
-    const error: Error = this.props.catalog.searchError
-    if (!error) {
+    if (!this.props.catalog.searchError) {
       return  // Nothing to do
     }
 
     let heading, details, stacktrace
 
-    stacktrace = error.toString()
+    stacktrace = this.props.catalog.searchError.toString()
 
-    const {response} = error as AxiosError
+    const {response} = this.props.catalog.searchError
     switch (response && response.status) {
       case 401:
       case 403:
@@ -227,7 +226,7 @@ export class CatalogSearchCriteria extends React.Component<Props> {
       default:
         heading = 'Search failed'
         details = 'An unknown error has occurred. Please contact the Beachfront team for technical support.'
-        stacktrace = error.stack
+        stacktrace = this.props.catalog.searchError.stack
         break
     }
 

--- a/src/reducers/algorithmsReducer.ts
+++ b/src/reducers/algorithmsReducer.ts
@@ -16,11 +16,12 @@
 
 import {Action} from 'redux'
 import {AlgorithmsActions as Actions} from '../actions/algorithmsActions'
+import {RequestError} from '../utils/requestError'
 
 export interface AlgorithmsState {
   readonly records: beachfront.Algorithm[]
   readonly isFetching: boolean
-  readonly fetchError: any
+  readonly fetchError: RequestError | null
 }
 
 export const algorithmsInitialState: AlgorithmsState = {

--- a/src/reducers/apiStatusReducer.ts
+++ b/src/reducers/apiStatusReducer.ts
@@ -16,6 +16,7 @@
 
 import {ApiStatusActions as Actions} from '../actions/apiStatusActions'
 import {Action} from 'redux'
+import {RequestError} from '../utils/requestError'
 
 export interface ApiStatusState {
   readonly geoserver: {
@@ -23,7 +24,7 @@ export interface ApiStatusState {
   }
   readonly enabledPlatforms: string[]
   readonly isFetching: boolean
-  readonly fetchError: any
+  readonly fetchError: RequestError | null
 }
 
 export const apiStatusInitialState: ApiStatusState = {

--- a/src/reducers/catalogReducer.ts
+++ b/src/reducers/catalogReducer.ts
@@ -19,6 +19,7 @@ import {CatalogActions as Actions} from '../actions/catalogActions'
 import {MapActions} from '../actions/mapActions'
 import * as moment from 'moment'
 import {SOURCE_DEFAULT} from '../constants'
+import {RequestError} from '../utils/requestError'
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 
@@ -31,7 +32,7 @@ export interface CatalogState {
     readonly dateTo: string
     readonly source: string
   },
-  readonly searchError: any
+  readonly searchError: RequestError | null
   readonly searchResults: beachfront.ImageryCatalogPage | null
 }
 

--- a/src/reducers/jobsReducer.ts
+++ b/src/reducers/jobsReducer.ts
@@ -16,21 +16,22 @@
 
 import {Action} from 'redux'
 import {JobsActions as Actions} from '../actions/jobsActions'
+import {RequestError} from '../utils/requestError'
 
 export type JobsState = {
   readonly records: beachfront.Job[]
   readonly isFetching: boolean
-  readonly fetchError: any
+  readonly fetchError: RequestError | null
   readonly initialFetchComplete: boolean
   readonly isFetchingOne: boolean
-  readonly fetchOneError: any
+  readonly fetchOneError: RequestError | null
   readonly lastOneFetched: beachfront.Job | null
   readonly isDeletingJob: boolean
   readonly deletedJob: beachfront.Job | null
-  readonly deleteJobError: any
+  readonly deleteJobError: RequestError | null
   readonly isCreatingJob: boolean
   readonly createdJob: beachfront.Job | null
-  readonly createJobError: any
+  readonly createJobError: RequestError | null
 }
 
 export const jobsInitialState: JobsState = {

--- a/src/reducers/productLinesReducer.ts
+++ b/src/reducers/productLinesReducer.ts
@@ -16,17 +16,18 @@
 
 import {Action} from 'redux'
 import {ProductLinesActions as Actions} from '../actions/productLinesActions'
+import {RequestError} from '../utils/requestError'
 
 export interface ProductLinesState {
   readonly records: beachfront.ProductLine[]
   readonly isFetching: boolean
-  readonly fetchError: any
+  readonly fetchError: RequestError | null
   readonly jobs: beachfront.Job[]
   readonly isFetchingJobs: boolean
-  readonly fetchJobsError: any
+  readonly fetchJobsError: RequestError | null
   readonly isCreatingProductLine: boolean
   readonly createdProductLine: beachfront.ProductLine | null
-  readonly createProductLineError: any
+  readonly createProductLineError: RequestError | null
 }
 
 export const productLinesInitialState: ProductLinesState = {

--- a/src/utils/requestError.ts
+++ b/src/utils/requestError.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018, RadiantBlue Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AxiosResponse} from 'axios'
+
+export class RequestError extends Error {
+  code?: string
+  response?: AxiosResponse
+}


### PR DESCRIPTION
Most errors were all using `any` before, which was not good. This should ensure that TypeScript will catch any misuse of errors.

I created a `RequestError` class that can be used when you're not sure whether to expect a regular error or an axios error to be thrown in a try-catch. So now, anywhere a try-catch is surrounding a block of code where a request is made, you can safely treat any error thrown as a `RequestError`. It's a tiny bit of a hack, but it avoids a lot of conditionals throughout the codebase to check each error's type.